### PR TITLE
braille: make sure liblouis emits pure BRF output

### DIFF
--- a/filter/braille/filters/musicxmltobrf.in
+++ b/filter/braille/filters/musicxmltobrf.in
@@ -40,7 +40,7 @@ checkTool FreeDots FreeDots "translating musicxml files"
 checkTool lou_translate liblouis "translating musicxml files"
 
 CONVERT="FreeDots -nw -w $TEXTWIDTH /dev/stdin"
-TRANSLATE="lou_translate $LIBLOUIS_TABLES,braille-patterns.cti"
+TRANSLATE="lou_translate en-us-brf.dis,$LIBLOUIS_TABLES,braille-patterns.cti"
 
 cd $TMPDIR
 echo "INFO: Translating MusicXML" >&2

--- a/filter/braille/filters/texttobrf.in
+++ b/filter/braille/filters/texttobrf.in
@@ -154,13 +154,13 @@ then
 	exit 1
 	;;
     esac
-    RENDER_CALL="$LIBLOUIS_TOOL -CliteraryTextTable=$LIBLOUIS_TABLES,braille-patterns.cti $LIBLOUIS_CONFIG"
+    RENDER_CALL="$LIBLOUIS_TOOL -CliteraryTextTable=en-us-brf.dis,$LIBLOUIS_TABLES,braille-patterns.cti $LIBLOUIS_CONFIG"
   elif type lou_translate > /dev/null
   then
     # Only liblouis, but better than nothing
     setupTextRendering
     printf "WARN: The liblouisutdml package is required for translating braille better\n" >&2
-    TRANSLATE="lou_translate $LIBLOUIS_TABLES,braille-patterns.cti"
+    TRANSLATE="lou_translate en-us-brf.dis,$LIBLOUIS_TABLES,braille-patterns.cti"
   else
     printf "ERROR: The liblouisutdml package is required for translating braille\n" >&2
     exit 1


### PR DESCRIPTION
We need to make sure to use the brf table first, in case the table being
used defines other display encodings.