### PR TITLE
braille: use application/vnd.cups-brf instead of text/vnd.cups-brf

### DIFF
--- a/drv/generic-brf.drv
+++ b/drv/generic-brf.drv
@@ -35,7 +35,7 @@ Version 1.0
 
 Throughput 1
 
-Filter text/vnd.cups-brf 0 brftoembosser
+Filter application/vnd.cups-brf 0 brftoembosser
 Filter image/vnd.cups-brf 0 brftoembosser
 
 MediaSize Legal

--- a/drv/indexv3.drv
+++ b/drv/indexv3.drv
@@ -34,7 +34,7 @@
 Manufacturer "Index"
 Version 1.0
 
-Filter text/vnd.cups-brf 0 textbrftoindexv3
+Filter application/vnd.cups-brf 0 textbrftoindexv3
 Filter image/vnd.cups-ubrl 0 imageubrltoindexv3
 
 //

--- a/drv/indexv4.drv
+++ b/drv/indexv4.drv
@@ -34,7 +34,7 @@
 Manufacturer "Index"
 Version 1.0
 
-Filter text/vnd.cups-brf 0 textbrftoindexv4
+Filter application/vnd.cups-brf 0 textbrftoindexv4
 Filter image/vnd.cups-ubrl 0 imageubrltoindexv4
 
 //

--- a/mime/braille.convs
+++ b/mime/braille.convs
@@ -23,42 +23,42 @@
 # 
 
 # Textual conversions
-text/plain		text/vnd.cups-brf	0	texttobrf
+text/plain		application/vnd.cups-brf	0	texttobrf
 
-text/html		text/vnd.cups-brf	10	texttobrf
-application/xhtml	text/vnd.cups-brf	10	texttobrf
-application/xml		text/vnd.cups-brf	10	texttobrf
-application/sgml	text/vnd.cups-brf	10	texttobrf
+text/html		application/vnd.cups-brf	10	texttobrf
+application/xhtml	application/vnd.cups-brf	10	texttobrf
+application/xml		application/vnd.cups-brf	10	texttobrf
+application/sgml	application/vnd.cups-brf	10	texttobrf
 
-application/vnd.recordare.musicxml+xml text/vnd.cups-brf	30	musicxmltobrf
+application/vnd.recordare.musicxml+xml application/vnd.cups-brf	30	musicxmltobrf
 
-application/vnd.oasis.opendocument.chart			text/vnd.cups-brf	30	texttobrf
-application/vnd.oasis.opendocument.formula			text/vnd.cups-brf	30	texttobrf
-application/vnd.oasis.opendocument.graphics			text/vnd.cups-brf	30	texttobrf
-application/vnd.oasis.opendocument.graphics-template		text/vnd.cups-brf	30	texttobrf
-application/vnd.oasis.opendocument.presentation			text/vnd.cups-brf	30	texttobrf
-application/vnd.oasis.opendocument.presentation-template	text/vnd.cups-brf	30	texttobrf
-application/vnd.oasis.opendocument.spreadsheet			text/vnd.cups-brf	30	texttobrf
-application/vnd.oasis.opendocument.spreadsheet-template		text/vnd.cups-brf	30	texttobrf
-application/vnd.oasis.opendocument.text				text/vnd.cups-brf	30	texttobrf
-application/vnd.oasis.opendocument.text-master			text/vnd.cups-brf	30	texttobrf
-application/vnd.oasis.opendocument.text-template		text/vnd.cups-brf	30	texttobrf
-application/vnd.oasis.opendocument.text-web			text/vnd.cups-brf	30	texttobrf
+application/vnd.oasis.opendocument.chart			application/vnd.cups-brf	30	texttobrf
+application/vnd.oasis.opendocument.formula			application/vnd.cups-brf	30	texttobrf
+application/vnd.oasis.opendocument.graphics			application/vnd.cups-brf	30	texttobrf
+application/vnd.oasis.opendocument.graphics-template		application/vnd.cups-brf	30	texttobrf
+application/vnd.oasis.opendocument.presentation			application/vnd.cups-brf	30	texttobrf
+application/vnd.oasis.opendocument.presentation-template	application/vnd.cups-brf	30	texttobrf
+application/vnd.oasis.opendocument.spreadsheet			application/vnd.cups-brf	30	texttobrf
+application/vnd.oasis.opendocument.spreadsheet-template		application/vnd.cups-brf	30	texttobrf
+application/vnd.oasis.opendocument.text				application/vnd.cups-brf	30	texttobrf
+application/vnd.oasis.opendocument.text-master			application/vnd.cups-brf	30	texttobrf
+application/vnd.oasis.opendocument.text-template		application/vnd.cups-brf	30	texttobrf
+application/vnd.oasis.opendocument.text-web			application/vnd.cups-brf	30	texttobrf
 
-application/msword	text/vnd.cups-brf	30	texttobrf
-application/vnd.openxmlformats-officedocument.presentationml.presentation	text/vnd.cups-brf	30	texttobrf
-application/vnd.openxmlformats-officedocument.presentationml.slide		text/vnd.cups-brf	30	texttobrf
-application/vnd.openxmlformats-officedocument.presentationml.slideshow		text/vnd.cups-brf	30	texttobrf
-application/vnd.openxmlformats-officedocument.presentationml.template		text/vnd.cups-brf	30	texttobrf
-application/vnd.openxmlformats-officedocument.spreadsheetml.sheet		text/vnd.cups-brf	30	texttobrf
-application/vnd.openxmlformats-officedocument.spreadsheetml.template		text/vnd.cups-brf	30	texttobrf
-application/vnd.openxmlformats-officedocument.wordprocessingml.document		text/vnd.cups-brf	30	texttobrf
-application/vnd.openxmlformats-officedocument.wordprocessingml.template		text/vnd.cups-brf	30	texttobrf
+application/msword	application/vnd.cups-brf	30	texttobrf
+application/vnd.openxmlformats-officedocument.presentationml.presentation	application/vnd.cups-brf	30	texttobrf
+application/vnd.openxmlformats-officedocument.presentationml.slide		application/vnd.cups-brf	30	texttobrf
+application/vnd.openxmlformats-officedocument.presentationml.slideshow		application/vnd.cups-brf	30	texttobrf
+application/vnd.openxmlformats-officedocument.presentationml.template		application/vnd.cups-brf	30	texttobrf
+application/vnd.openxmlformats-officedocument.spreadsheetml.sheet		application/vnd.cups-brf	30	texttobrf
+application/vnd.openxmlformats-officedocument.spreadsheetml.template		application/vnd.cups-brf	30	texttobrf
+application/vnd.openxmlformats-officedocument.wordprocessingml.document		application/vnd.cups-brf	30	texttobrf
+application/vnd.openxmlformats-officedocument.wordprocessingml.template		application/vnd.cups-brf	30	texttobrf
 
-text/rtf		text/vnd.cups-brf	30	texttobrf
-application/rtf		text/vnd.cups-brf	30	texttobrf
+text/rtf		application/vnd.cups-brf	30	texttobrf
+application/rtf		application/vnd.cups-brf	30	texttobrf
 
-application/pdf		text/vnd.cups-brf	100	texttobrf
+application/pdf		application/vnd.cups-brf	100	texttobrf
 
 
 # Picture conversions

--- a/mime/braille.types
+++ b/mime/braille.types
@@ -22,8 +22,8 @@
 # THE SOFTWARE.
 # 
 
-text/vnd.cups-brf	brf
-text/vnd.cups-ubrl
+application/vnd.cups-brf	brf
+application/vnd.cups-ubrl
 image/vnd.cups-brf
 image/vnd.cups-ubrl
 image/vnd.cups-pdf


### PR DESCRIPTION
When using a text/ MIME type, detection for .brf files would always
discover text/plain, instead of text/vnd.cups-brf, thus preventing from
directly embossing files by running .brf. Using application/vnd.cups-brf
avoids detection from trying to be too smart.