### PR TITLE
.gitignore: Add 'filter/braille/filters/brftopagedbrf'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ filter/braille/drivers/index/imageubrltoindexv[34]
 filter/braille/drivers/index/index.sh
 filter/braille/drivers/index/indexv[34].sh
 filter/braille/drivers/index/textbrftoindexv3
+filter/braille/filters/brftopagedbrf
 filter/braille/filters/cups-braille.sh
 filter/braille/filters/imagetobrf
 filter/braille/filters/liblouis1.defs.gen


### PR DESCRIPTION
Add  `filter/braille/filters/brftopagedbrf` to `.gitignore` since this file is automatically generated by [`filter/braille/filters/brftopagedbrf.in`](https://github.com/OpenPrinting/cups-filters/blob/master/filter/braille/filters/brftopagedbrf.in)