### PR TITLE
Do not remove read permission on cups-brf

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1090,7 +1090,7 @@ endif
 	$(LN_S) -f pdf.utf-8.simple \
 		$(DESTDIR)$(pkgcharsetdir)/pdf.utf-8
 if ENABLE_BRAILLE
-	chmod g-rwx,o-rwx $(DESTDIR)/$(pkgbackenddir)/cups-brf
+	chmod g-wx,o-wx $(DESTDIR)/$(pkgbackenddir)/cups-brf
 endif
 
 


### PR DESCRIPTION
cups checks only for executability and writability, while checksumming tools
need to be able to read files easily.