### PR TITLE
Revert "driverless, foomatic-rip: Create relative symbolic links."

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1066,11 +1066,11 @@ install-exec-hook:
 	$(INSTALL) -d -m 755 $(DESTDIR)$(pkgfilterdir)
 	$(INSTALL) -d -m 755 $(DESTDIR)$(pkgbackenddir)
 if ENABLE_FOOMATIC
-	$(LN_S) -r -f $(DESTDIR)$(pkgfilterdir)/foomatic-rip $(DESTDIR)$(bindir)
+	$(LN_S) -f $(pkgfilterdir)/foomatic-rip $(DESTDIR)$(bindir)
 endif
 if ENABLE_DRIVERLESS
-	$(LN_S) -r -f $(DESTDIR)$(pkgppdgendir)/driverless $(DESTDIR)$(bindir)
-	$(LN_S) -r -f $(DESTDIR)$(pkgppdgendir)/driverless $(DESTDIR)$(pkgbackenddir)
+	$(LN_S) -f $(pkgppdgendir)/driverless $(DESTDIR)$(bindir)
+	$(LN_S) -f $(pkgppdgendir)/driverless $(DESTDIR)$(pkgbackenddir)
 endif
 if ENABLE_BRAILLE
 	$(LN_S) -f imagetobrf $(DESTDIR)$(pkgfilterdir)/imagetoubrl


### PR DESCRIPTION
This reverts commit 0297a70022e366c56e3c8d4b1036df80874d8bb4.

The `-r`/`--relative` flag in `ln` is a GNU extension, and this commit adds a
somewhat unnecessary dependency on GNU coreutils. Reverting this allows for
building with other coreutils implementations, like Busybox.