### PR TITLE
Poppler removed memCheck and gMemReport functions

### DIFF
--- a/filter/pdftoijs.cxx
+++ b/filter/pdftoijs.cxx
@@ -503,9 +503,11 @@ err1:
   ppdClose(ppd);
   free(outputfile);
 
+#if POPPLER_VERSION_MAJOR == 0 && POPPLER_VERSION_MINOR < 69
   // Check for memory leaks
   Object::memCheck(stderr);
   gMemReport(stderr);
+#endif
 
   return exitCode;
 }

--- a/filter/pdftoopvp/pdftoopvp.cxx
+++ b/filter/pdftoopvp/pdftoopvp.cxx
@@ -763,9 +763,11 @@ err2:
  err0:
   delete globalParams;
 
+#if POPPLER_VERSION_MAJOR == 0 && POPPLER_VERSION_MINOR < 69
   // check for memory leaks
   Object::memCheck(stderr);
   gMemReport(stderr);
+#endif
 
 }
 /* muntrace(); */

--- a/filter/pdftoraster.cxx
+++ b/filter/pdftoraster.cxx
@@ -2162,9 +2162,11 @@ err1:
     cmsDeleteTransform(colorTransform);
   }
 
+#if POPPLER_VERSION_MAJOR == 0 && POPPLER_VERSION_MINOR < 69
   // Check for memory leaks
   Object::memCheck(stderr);
   gMemReport(stderr);
+#endif
 
   return exitCode;
 }


### PR DESCRIPTION
Only use gMemReport and memCheck functions if poppler version less
than 0.69.0

The poppler project removed the memCheck and gMemReport functions in
commits c362ab1b97f20c5b73b3bad8d52015f679178748 - Remove DEBUG_MEM
from Object since this uses RAII now and hence cannot leak.
(The existing tracking also is not thread-safe and hence unreliable.)

and

f89446f6917a869b0f1a80fcc8ce81a7213dade4 - Remove generic heap debugging
from gmem since external tools and compiler instrumentation achieve the
same effect.

This commit solves https://github.com/OpenPrinting/cups-filters/issues/62

Signed-off-by: Olivier Schonken <olivier.schonken@gmail.com>