### PR TITLE
Introduce HttpMaxRetries directive

### DIFF
--- a/utils/cups-browsed.conf.5
+++ b/utils/cups-browsed.conf.5
@@ -429,6 +429,18 @@ when the server does not respond.
 
 .fam T
 .fi
+Set how many retries (N) should daemon do for creating print queues for
+remote printers which receive timeouts during print queue creation.
+The printers, which is not successfuly installed even after N retries,
+are skipped until restart of service.
+Note that too many retries can cause high CPU load.
+.PP
+.nf
+.fam C
+        HttpMaxRetries 5
+
+.fam T
+.fi
 The interval between browsing/broadcasting cycles, local and/or
 remote, can be adjusted with the BrowseInterval directive.
 .PP

--- a/utils/cups-browsed.conf.in
+++ b/utils/cups-browsed.conf.in
@@ -310,6 +310,13 @@ BrowseRemoteProtocols @BROWSEREMOTEPROTOCOLS@
 # HttpLocalTimeout 5
 # HttpRemoteTimeout 10
 
+# Set how many retries (N) should daemon do for creating print queues for
+# remote printers which receive timeouts during print queue creation.
+# The printers, which is not successfuly installed even after N retries,
+# are skipped until restart of service.
+# Note that too many retries can cause high CPU load.
+
+# HttpMaxRetries 5
 
 # Set OnlyUnsupportedByCUPS to "Yes" will make cups-browsed not create
 # local queues for remote printers for which CUPS creates queues by


### PR DESCRIPTION
Hi Till,

I created for https://bugzilla.redhat.com/show_bug.cgi?id=1648697 feature to cups-browsed, about which we talked in #71 - cups-browsed will skip printers, which had N unsuccessful tries for print queue creation due timeouts during print queue creation, until restart of service.
I created HttpMaxRetries directive for possible manual settings of HttpMaxRetries (possible values > 0), defaults to 5. 
Does it look fine?

Zdenek