### PR TITLE
cups-browsed, driverless: request urf-supported attribute

### DIFF
--- a/utils/cups-browsed.c
+++ b/utils/cups-browsed.c
@@ -3849,7 +3849,8 @@ get_printer_attributes(const char* uri) {
     "job-template",
     "printer-defaults",
     "printer-description",
-    "media-col-database"
+    "media-col-database",
+    "urf-supported"
   };
   /* Request printer properties via IPP to generate a PPD file for the
      printer (mainly driverless-capable printers)

--- a/utils/driverless.c
+++ b/utils/driverless.c
@@ -482,7 +482,8 @@ generate_ppd (const char *uri)
     "job-template",
     "printer-defaults",
     "printer-description",
-    "media-col-database"
+    "media-col-database",
+    "urf-supported"
   };
 
   /* Request printer properties via IPP to generate a PPD file for the


### PR DESCRIPTION
Fixes bug #22 - at least for me (I have a Canon Pixma MG4250 printer).

I have not tested other Canon models, so can't be certain that this will fix it for other Pixma variants referred to in the bug report (and also can't be sure that requesting this attribute won't be a breaking change for other printers).