### PR TITLE
Do not do IPP request for printer-is-shared option for remote cups qu…

### DIFF
--- a/utils/cups-browsed.c
+++ b/utils/cups-browsed.c
@@ -451,6 +451,19 @@ static remote_printer_t
 #endif
 
 /*
+ * Option 'printer-is-shared' cannot be set on remote CUPS
+ * queue and requests for setting it ends with error since
+ * 2.1.1. Define HAVE_CUPS_2_2 to do not send IPP request
+ * for setting 'printer-is-shared' option on remote CUPS queues
+ * for newer versions of CUPS.
+ */
+#if (CUPS_VERSION_MAJOR > 2) || (CUPS_VERSION_MINOR > 1)
+#define HAVE_CUPS_2_2 1
+#else
+#define HAVE_CUPS_2_2 0
+#endif
+
+/*
  * CUPS 1.6 makes various structures private and
  * introduces these ippGet and ippSet functions
  * for all of the fields in these structures.
@@ -5438,7 +5451,15 @@ gboolean update_cups_queues(gpointer unused) {
       }
       cupsEncodeOptions2(request, num_options, options, IPP_TAG_OPERATION);
       cupsEncodeOptions2(request, num_options, options, IPP_TAG_PRINTER);
-      ippDelete(cupsDoRequest(http, request, "/admin/"));
+      /*
+       * Do IPP request for printer-is-shared option only when we have
+       * network printer or if we have remote CUPS queue, do IPP request
+       * only if we have CUPS older than 2.2.
+       */
+      if (p->netprinter != 0 || !HAVE_CUPS_2_2)
+        ippDelete(cupsDoRequest(http, request, "/admin/"));
+      else
+        ippDelete(request);
       cupsFreeOptions(num_options, options);
       if (cupsLastError() > IPP_STATUS_OK_EVENTS_COMPLETE)
 	debug_printf("Unable to modify the printer-is-shared bit (%s)!\n",


### PR DESCRIPTION
…eues with CUPS 2.2 and newer

Hi!

I found out there are lots of error messages in journal from CUPS in Fedora 28 (cups-filters-1.20.0, cups-2.2.6), when I run cups-browsed with BrowsePoll directive set on remote CUPS server (RHEL 6, cups-1.4.2) like:

[Client 13] Returning IPP client-error-bad-request for CUPS-Add-Modify-Printer (ipp://localhost:631/printers/print_queue_name) from localhost

It is caused by cups-browsed trying to set printer-is-shared option to false for remote CUPS queue, which is forbidden by CUPS as you wrote in comments in the code.
It is harmless error, but it can mystify an user and log is IMHO nicer without such errors.
I introduced a new macro in cups-browsed.c, HAVE_CUPS_2_2, to indicate if we have cups-2.2 or newer in the fix. Then, in update_cups_queues(), when function is issuing a request for printer-is-shared option, do not request the option when the print queue is remote CUPS queue and we have CUPS-2.2 or newer.

Does it look ok? Would it be possible to add it to the project? I tried it on Fedora 28 machine, remote cups queue was found, with no errors in logs, and it prints fine.

Thank you in advance and have a nice day!

Zdenek