### PR TITLE
Added print-scaling=fill functionality.

### DIFF
--- a/cupsfilters/image.c
+++ b/cupsfilters/image.c
@@ -807,3 +807,30 @@ get_tile(cups_image_t *img,		/* I - Image */
   return (ic->pixels + bpp * (y * CUPS_TILE_SIZE + x));
 }
 
+/*
+ * Crop a image.
+ * (posw,posh): Position of left corner
+ * (width,height): width and height of required image.
+ */
+cups_image_t* cupsImageCrop(cups_image_t* img,int posw,int posh,int width,int height)
+{
+  int image_width = cupsImageGetWidth(img);
+  cups_image_t* temp=calloc(sizeof(cups_image_t),1);
+  cups_ib_t *pixels=(cups_ib_t*)malloc(img->xsize*cupsImageGetDepth(img));
+  temp->cachefile = -1;
+  temp->max_ics = CUPS_TILE_MINIMUM;
+  temp->colorspace=img->colorspace;
+  temp->xppi = img->xppi;
+  temp->yppi = img->yppi;
+  temp->num_ics = 0;
+  temp->first =temp->last = NULL;
+  temp->tiles = NULL;
+  temp->xsize = width;
+  temp->ysize = height;
+  for(int i=posh;i<min(cupsImageGetHeight(img),posh+height);i++){
+    cupsImageGetRow(img,posw,i,min(width,image_width-posw),pixels);
+    _cupsImagePutRow(temp,0,i-posh,min(width,image_width-posw),pixels);
+  }
+  free(pixels);
+  return temp;
+}

--- a/cupsfilters/image.h
+++ b/cupsfilters/image.h
@@ -112,7 +112,8 @@ extern void		cupsImageWhiteToRGB(const cups_ib_t *in,
 			                    cups_ib_t *out, int count) _CUPS_API_1_2;
 extern void		cupsImageWhiteToWhite(const cups_ib_t *in,
 			                      cups_ib_t *out, int count) _CUPS_API_1_2;
-
+extern cups_image_t* 	cupsImageCrop(cups_image_t* img,int posw,
+					int posh,int width,int height);
 
 #  ifdef __cplusplus
 }

--- a/filter/imagetopdf.c
+++ b/filter/imagetopdf.c
@@ -693,7 +693,7 @@ main(int  argc,				/* I - Number of command-line arguments */
   int deviceReverse = 0;
   ppd_attr_t *attr;
   int pl,pr;
-
+  int fillprint = 0;  /* print-scaling = fill */
  /*
   * Make sure status messages are not buffered...
   */
@@ -810,6 +810,14 @@ main(int  argc,				/* I - Number of command-line arguments */
       }
   }
 
+  /*
+  *   print-scaling = fill functionality.
+  */
+  if((val = cupsGetOption("print-scaling",num_options,options)) !=0) {
+    if(!strcasecmp(val,"fill")) {
+        fillprint = 1;
+    }
+  }
 
   if ((val = cupsGetOption("OutputOrder",num_options,options)) != 0) {
     if (!strcasecmp(val, "Reverse")) {
@@ -973,6 +981,61 @@ main(int  argc,				/* I - Number of command-line arguments */
   colorspace = ColorDevice ? CUPS_IMAGE_RGB_CMYK : CUPS_IMAGE_WHITE;
 
   img = cupsImageOpen(filename, colorspace, CUPS_IMAGE_WHITE, sat, hue, NULL);
+
+  if(fillprint)
+  {
+    float w = (float)cupsImageGetWidth(img);
+    float h = (float)cupsImageGetHeight(img);
+    float pw = PageRight-PageLeft;
+    float ph = PageTop-PageBottom;
+    char temp[3072];
+    char tempfilename[1024];
+    int tempOrientation = Orientation;
+    if ((cupsTempFd(tempfilename, sizeof(tempfilename))) < 0)
+    {
+      perror("ERROR: Unable to copy image file");
+      return (1);
+    }
+    char *val;
+    if((val = cupsGetOption("orientation-requested",num_options,options))!=NULL)
+    {
+      tempOrientation = atoi(val);
+    }
+    if(tempOrientation>0)
+    {
+      if(tempOrientation==4||tempOrientation==5)
+      {
+        float temp = pw;
+        pw = ph;
+        ph = temp;
+      }
+    }
+    if(tempOrientation==0)
+    {
+      float ratio = ph/pw;
+      if(h/w < ratio)
+      {
+        float temp = pw;
+        pw = ph;
+        ph = temp;
+      }
+    }
+    float final_w,final_h;
+    if(w*ph/pw <=h){
+      final_w =w;
+      final_h =w*ph/pw; 
+    }
+    else{
+      final_w = h*pw/ph;
+      final_h = h;
+    }
+    float posw=(w-final_w)/2,posh=(h-final_h)/2;
+    posw = (1+XPosition)*posw;
+    posh = (1-YPosition)*posh;
+    cups_image_t *img2 = cupsImageCrop(img,posw,posh,final_w,final_h);
+    cupsImageClose(img);
+    img = img2;
+  }
 
 #if defined(USE_CONVERT_CMD) && defined(CONVERT_CMD)
   if (img == NULL) {

--- a/filter/imagetopdf.c
+++ b/filter/imagetopdf.c
@@ -694,6 +694,7 @@ main(int  argc,				/* I - Number of command-line arguments */
   ppd_attr_t *attr;
   int pl,pr;
   int fillprint = 0;  /* print-scaling = fill */
+  int cropfit = 0;  /* -o crop-to-fit = true */
  /*
   * Make sure status messages are not buffered...
   */
@@ -816,6 +817,21 @@ main(int  argc,				/* I - Number of command-line arguments */
   if((val = cupsGetOption("print-scaling",num_options,options)) !=0) {
     if(!strcasecmp(val,"fill")) {
         fillprint = 1;
+    }
+  }
+  else if((val = cupsGetOption("fill",num_options,options))!=0) {
+    if(!strcasecmp(val,"true")||!strcasecmp(val,"yes"))
+    {
+      fillprint = 1;
+    }
+  }
+  /*
+   * crop-to-fit
+   */
+  if((val = cupsGetOption("crop-to-fit",num_options,options))!= NULL){
+    if(!strcasecmp(val,"true")||!strcasecmp(val,"yes"))
+    {
+      cropfit=1;
     }
   }
 
@@ -981,25 +997,25 @@ main(int  argc,				/* I - Number of command-line arguments */
   colorspace = ColorDevice ? CUPS_IMAGE_RGB_CMYK : CUPS_IMAGE_WHITE;
 
   img = cupsImageOpen(filename, colorspace, CUPS_IMAGE_WHITE, sat, hue, NULL);
-
-  if(fillprint)
+  if(fillprint||cropfit)
   {
     float w = (float)cupsImageGetWidth(img);
     float h = (float)cupsImageGetHeight(img);
     float pw = PageRight-PageLeft;
     float ph = PageTop-PageBottom;
-    char temp[3072];
-    char tempfilename[1024];
     int tempOrientation = Orientation;
-    if ((cupsTempFd(tempfilename, sizeof(tempfilename))) < 0)
-    {
-      perror("ERROR: Unable to copy image file");
-      return (1);
-    }
     char *val;
+    int flag = 3;
     if((val = cupsGetOption("orientation-requested",num_options,options))!=NULL)
     {
       tempOrientation = atoi(val);
+    }
+    else if((val = cupsGetOption("landscape",num_options,options))!=NULL)
+    {
+      if(!strcasecmp(val,"true")||!strcasecmp(val,"yes"))
+      {
+        tempOrientation = 4;
+      }
     }
     if(tempOrientation>0)
     {
@@ -1008,33 +1024,83 @@ main(int  argc,				/* I - Number of command-line arguments */
         float temp = pw;
         pw = ph;
         ph = temp;
+        flag = 4;
       }
     }
     if(tempOrientation==0)
     {
-      float ratio = ph/pw;
-      if(h/w < ratio)
+      int temp1 = pw,
+          temp2 = ph,
+          temp3 = pw,
+          temp4 = ph;
+      if(temp1>w) temp1 = w;
+      if(temp2>h) temp2 = h;
+      if(temp3>h) temp3 = h;
+      if(temp4>w) temp4 = w; 
+      if(temp1*temp2<temp3*temp4)
       {
-        float temp = pw;
+        int temp = pw;
         pw = ph;
         ph = temp;
+        flag = 4;
       }
     }
-    float final_w,final_h;
-    if(w*ph/pw <=h){
-      final_w =w;
-      final_h =w*ph/pw; 
+    if(fillprint){
+      float final_w,final_h;
+      if(w*ph/pw <=h){
+        final_w =w;
+        final_h =w*ph/pw; 
+      }
+      else{
+        final_w = h*pw/ph;
+        final_h = h;
+      }
+      float posw=(w-final_w)/2,posh=(h-final_h)/2;
+      posw = (1+XPosition)*posw;
+      posh = (1-YPosition)*posh;
+      cups_image_t *img2 = cupsImageCrop(img,posw,posh,final_w,final_h);
+      cupsImageClose(img);
+      img = img2;
     }
-    else{
-      final_w = h*pw/ph;
-      final_h = h;
+    else {
+      float final_w=w,final_h=h;
+      if(final_w>pw)
+      {
+        final_w = pw;
+      }
+      if(final_h>ph)
+      {
+        final_h = ph;
+      }
+      if((fabs(final_w-w)>0.5*w)||(fabs(final_h-h)>0.5*h))
+      {
+        fprintf(stderr,"[DEBUG]: Ignoring crop-to-fit option!\n");
+        cropfit=0;
+      }
+      else{
+        float posw=(w-final_w)/2,posh=(h-final_h)/2;
+        posw = (1+XPosition)*posw;
+        posh = (1-YPosition)*posh;
+        cups_image_t *img2 = cupsImageCrop(img,posw,posh,final_w,final_h);
+        cupsImageClose(img);
+        img = img2;
+        if(flag==4)
+        {
+          PageBottom+=(PageTop-PageBottom-final_w)/2;
+          PageTop = PageBottom+final_w;
+          PageLeft +=(PageRight-PageLeft-final_h)/2;
+          PageRight = PageLeft+final_h;
+        }
+        else{
+          PageBottom+=(PageTop-PageBottom-final_h)/2;
+          PageTop = PageBottom+final_h;
+          PageLeft +=(PageRight-PageLeft-final_w)/2;
+          PageRight = PageLeft+final_w;
+        }
+        if(PageBottom<0) PageBottom = 0;
+        if(PageLeft<0) PageLeft = 0;
+     }
     }
-    float posw=(w-final_w)/2,posh=(h-final_h)/2;
-    posw = (1+XPosition)*posw;
-    posh = (1-YPosition)*posh;
-    cups_image_t *img2 = cupsImageCrop(img,posw,posh,final_w,final_h);
-    cupsImageClose(img);
-    img = img2;
   }
 
 #if defined(USE_CONVERT_CMD) && defined(CONVERT_CMD)

--- a/filter/imagetoraster.c
+++ b/filter/imagetoraster.c
@@ -191,6 +191,7 @@ main(int  argc,				/* I - Number of command-line arguments */
   cm_calibration_t      cm_calibrate;   /* Are we color calibrating the device? */
   int                   cm_disabled;    /* Color management disabled? */
   int fillprint = 0;  /* print-scaling = fill */
+  int cropfit = 0;		/* -o crop-to-fit */
  /*
   * Make sure status messages are not buffered...
   */
@@ -392,6 +393,18 @@ main(int  argc,				/* I - Number of command-line arguments */
   if((val = cupsGetOption("print-scaling",num_options,options)) !=0) {
     if(!strcasecmp(val,"fill")) {
         fillprint = 1;
+    }
+  }
+  else if((val = cupsGetOption("fill",num_options,options))!=0) {
+    if(!strcasecmp(val,"true")||!strcasecmp(val,"yes"))
+    {
+      fillprint = 1;
+    }
+  }
+  if((val = cupsGetOption("crop-to-fit",num_options,options))!= NULL){
+    if(!strcasecmp(val,"true")||!strcasecmp(val,"yes"))
+    {
+      cropfit=1;
     }
   }
 
@@ -696,23 +709,25 @@ main(int  argc,				/* I - Number of command-line arguments */
     img = cupsImageOpen(filename, primary, secondary, sat, hue, lut);
   if(img!=NULL)
   {
-    if(fillprint)
+    if(fillprint||cropfit)
     {
       float w = (float)cupsImageGetWidth(img);
       float h = (float)cupsImageGetHeight(img);
       float pw = PageRight-PageLeft;
       float ph = PageTop-PageBottom;
-      char temp[3072],*val;
-      char tempfilename[1024];
+      char *val;
       int tempOrientation = Orientation;
-      if ((cupsTempFd(tempfilename, sizeof(tempfilename))) < 0)
-      {
-        perror("ERROR: Unable to copy image file");
-        return (1);
-      }
+      int flag =3;
       if((val = cupsGetOption("orientation-requested",num_options,options))!=NULL)
       {
         tempOrientation = atoi(val);
+      }
+      else if((val = cupsGetOption("landscape",num_options,options))!=NULL)
+      {
+        if(!strcasecmp(val,"true")||!strcasecmp(val,"yes"))
+        {
+          tempOrientation = 4;
+        }
       }
       if(tempOrientation>0)
       {
@@ -721,35 +736,78 @@ main(int  argc,				/* I - Number of command-line arguments */
           float temp = pw;
           pw = ph;
           ph = temp;
+          flag = 4;
         }
       }
       if(tempOrientation==0)
       {
-        float ratio = ph/pw;
-        if(h/w < ratio)
+        if(min(pw,w)*min(ph,h)<min(pw,h)*min(ph,w))
         {
-          float temp = pw;
+          int temp = pw;
           pw = ph;
           ph = temp;
+          flag = 4;
         }
       }
-      // Final width and height of cropped image.
-      float final_w,final_h;
-      if(w*ph/pw <=h){
-        final_w =w;
-        final_h =w*ph/pw; 
+      if(fillprint)
+      {
+        // Final width and height of cropped image.
+        float final_w,final_h;
+        if(w*ph/pw <=h){
+          final_w =w;
+          final_h =w*ph/pw; 
+        }
+        else{
+          final_w = h*pw/ph;
+          final_h = h;
+        }
+        // posw and posh are position of the cropped image along width and height.
+        float posw=(w-final_w)/2,posh=(h-final_h)/2;
+        posw = (1+XPosition)*posw;
+        posh = (1-YPosition)*posh;
+        cups_image_t *img2 = cupsImageCrop(img,posw,posh,final_w,final_h);
+        cupsImageClose(img);
+        img = img2;
       }
-      else{
-        final_w = h*pw/ph;
-        final_h = h;
-      }
-      // posw and posh are position of the cropped image along width and height.
-      float posw=(w-final_w)/2,posh=(h-final_h)/2;
-      posw = (1+XPosition)*posw;
-      posh = (1-YPosition)*posh;
-      cups_image_t *img2 = cupsImageCrop(img,posw,posh,final_w,final_h);
-      cupsImageClose(img);
-      img = img2;
+      else {
+        float final_w=w,final_h=h;
+        if(w>pw)
+        {
+          final_w = pw;
+        }
+        if(h>ph)
+        {
+          final_h = ph;
+        }
+        if((fabs(final_w-w)>0.5*w)||(fabs(final_h-h)>0.5*h))
+        {
+          fprintf(stderr,"[DEBUG]: Ignoring crop-to-fit option!\n");
+          cropfit=0;
+        }
+        else{
+          float posw=(w-final_w)/2,posh=(h-final_h)/2;
+          posw = (1+XPosition)*posw;
+          posh = (1-YPosition)*posh;
+          cups_image_t *img2 = cupsImageCrop(img,posw,posh,final_w,final_h);
+          cupsImageClose(img);
+          img = img2;
+          if(flag==4)
+          {
+            PageBottom+=(PageTop-PageBottom-final_w)/2;
+            PageTop = PageBottom+final_w;
+            PageLeft +=(PageRight-PageLeft-final_h)/2;
+            PageRight = PageLeft+final_h;
+          }
+          else{
+            PageBottom+=(PageTop-PageBottom-final_h)/2;
+            PageTop = PageBottom+final_h;
+            PageLeft +=(PageRight-PageLeft-final_w)/2;
+            PageRight = PageLeft+final_w;
+          }
+          if(PageBottom<0) PageBottom = 0;
+          if(PageLeft<0) PageLeft = 0;
+        }
+      }	
     }
   }
   if (argc == 6)

--- a/filter/pdftopdf/pdftopdf.cc
+++ b/filter/pdftopdf/pdftopdf.cc
@@ -326,6 +326,12 @@ void getParameters(ppd_file_t *ppd,int num_options,cups_option_t *options,Proces
   // TODO?  pstops checks =="true", pdftops !is_false  ... pstops says: fitplot only for PS (i.e. not for PDF, cmp. cgpdftopdf)
   param.fitplot=(val)&&(!is_false(val));
 
+  if((val=cupsGetOption("print-scaling",num_options,options))!=NULL) {
+    if(!strcasecmp(val,"fill")) {
+      param.fillprint=true;
+    }
+  }
+
   if (ppd && (ppd->landscape < 0)) { // direction the printer rotates landscape (90 or -90)
     param.normal_landscape=ROT_270;
   } else {
@@ -1023,6 +1029,7 @@ int main(int argc,char **argv)
     param.nup.nupY=2;
     //param.nup.yalign=TOP;
     param.border=BorderType::NONE;
+    //param.fillprint = true;
     //param.mirror=true;
     //param.reverse=true;
     //param.numCopies=3;

--- a/filter/pdftopdf/pdftopdf.cc
+++ b/filter/pdftopdf/pdftopdf.cc
@@ -331,6 +331,21 @@ void getParameters(ppd_file_t *ppd,int num_options,cups_option_t *options,Proces
       param.fillprint=true;
     }
   }
+  else if((val = cupsGetOption("fill",num_options,options))!=0) {
+    if(!strcasecmp(val,"true")||!strcasecmp(val,"yes"))
+    {
+      param.fillprint = true;
+    }
+  }
+  /*
+   * crop-to-fit
+   */
+  if((val = cupsGetOption("crop-to-fit",num_options,options))!= NULL){
+    if(!strcasecmp(val,"true")||!strcasecmp(val,"yes"))
+    {
+      param.cropfit=1;
+    }
+  }
 
   if (ppd && (ppd->landscape < 0)) { // direction the printer rotates landscape (90 or -90)
     param.normal_landscape=ROT_270;

--- a/filter/pdftopdf/pdftopdf_processor.cc
+++ b/filter/pdftopdf/pdftopdf_processor.cc
@@ -175,6 +175,16 @@ bool processPDFTOPDF(PDFTOPDF_Processor &proc,ProcessingParameters &param) // {{
   }
   const int numPages=std::max(shuffle.size(),pages.size());
 
+  if(param.fillprint){
+    fprintf(stderr,"Cropping input pdf and Enabling fitplot.%d\n");
+    for(int i=0;i<pages.size();i++)
+    {
+      std::shared_ptr<PDFTOPDF_PageHandle> page = pages[i];
+      Rotation currRot = page->crop(param.page,param.orientation,param.xpos,param.ypos);
+    }
+    param.fitplot = 1;
+  }
+
   std::shared_ptr<PDFTOPDF_PageHandle> curpage;
   int outputpage=0;
   int outputno=0;

--- a/filter/pdftopdf/pdftopdf_processor.cc
+++ b/filter/pdftopdf/pdftopdf_processor.cc
@@ -175,12 +175,12 @@ bool processPDFTOPDF(PDFTOPDF_Processor &proc,ProcessingParameters &param) // {{
   }
   const int numPages=std::max(shuffle.size(),pages.size());
 
-  if(param.fillprint){
-    fprintf(stderr,"Cropping input pdf and Enabling fitplot.%d\n");
-    for(int i=0;i<pages.size();i++)
+  if(param.fillprint||param.cropfit){
+    fprintf(stderr,"[DEBUG]: Cropping input pdf and Enabling fitplot.\n");
+    for(int i=0;i<(int)pages.size();i++)
     {
       std::shared_ptr<PDFTOPDF_PageHandle> page = pages[i];
-      Rotation currRot = page->crop(param.page,param.orientation,param.xpos,param.ypos);
+      Rotation currRot = page->crop(param.page,param.orientation,param.xpos,param.ypos,!param.cropfit);
     }
     param.fitplot = 1;
   }
@@ -332,7 +332,20 @@ bool processPDFTOPDF(PDFTOPDF_Processor &proc,ProcessingParameters &param) // {{
       if (!param.fitplot) {
         curpage->add_subpage(page,pgedit.xpos+xpos,pgedit.ypos+ypos,pgedit.scale,&rect);
       } else {
-        curpage->add_subpage(page,pgedit.xpos+xpos,pgedit.ypos+ypos,pgedit.scale);
+        if(param.cropfit){
+          double xpos2 = (param.page.right-param.page.left-(page->getRect().width))/2;
+          double ypos2 = (param.page.top-param.page.bottom-(page->getRect().height))/2;
+          if(param.orientation==ROT_270||param.orientation==ROT_90)
+          {
+            xpos2 = (param.page.right-param.page.left-(page->getRect().height))/2;
+            ypos2 = (param.page.top-param.page.bottom-(page->getRect().width))/2;
+            curpage->add_subpage(page,ypos2+param.page.bottom,xpos2+param.page.left,1);
+          }else{
+          curpage->add_subpage(page,xpos2+param.page.left,ypos2+param.page.bottom,1);
+          }
+        }
+        else
+          curpage->add_subpage(page,pgedit.xpos+xpos,pgedit.ypos+ypos,pgedit.scale);
       }
 
 #ifdef DEBUG

--- a/filter/pdftopdf/pdftopdf_processor.h
+++ b/filter/pdftopdf/pdftopdf_processor.h
@@ -15,6 +15,7 @@ ProcessingParameters()
     user(0),title(0),
     fitplot(false),
     fillprint(false),  //print-scaling = fill
+    cropfit(false),
     orientation(ROT_0),normal_landscape(ROT_270),
     paper_is_landscape(false),
     duplex(false),
@@ -56,6 +57,7 @@ ProcessingParameters()
   const char *user, *title; // will stay around
   bool fitplot;
   bool fillprint;   //print-scaling = fill
+  bool cropfit;     // -o crop-to-fit
   PageRect page;
   Rotation orientation,normal_landscape;  // normal_landscape (i.e. default direction) is e.g. needed for number-up=2
   bool paper_is_landscape;
@@ -108,7 +110,7 @@ class PDFTOPDF_PageHandle {
   // fscale:  inverse_scale (from nup, fitplot)
   virtual void add_border_rect(const PageRect &rect,BorderType border,float fscale) =0;
   // TODO?! add standalone crop(...) method (not only for subpages)
-  virtual Rotation crop(const PageRect &cropRect,Rotation orientation,Position xpos,Position ypos) =0;
+  virtual Rotation crop(const PageRect &cropRect,Rotation orientation,Position xpos,Position ypos,bool scale) =0;
   virtual void add_subpage(const std::shared_ptr<PDFTOPDF_PageHandle> &sub,float xpos,float ypos,float scale,const PageRect *crop=NULL) =0;
   virtual void mirror() =0;
   virtual void rotate(Rotation rot) =0;

--- a/filter/pdftopdf/pdftopdf_processor.h
+++ b/filter/pdftopdf/pdftopdf_processor.h
@@ -14,6 +14,7 @@ ProcessingParameters()
 : jobId(0),numCopies(1),
     user(0),title(0),
     fitplot(false),
+    fillprint(false),  //print-scaling = fill
     orientation(ROT_0),normal_landscape(ROT_270),
     paper_is_landscape(false),
     duplex(false),
@@ -38,7 +39,6 @@ ProcessingParameters()
     deviceCollate(false),setDuplex(false),
 
     page_logging(-1)
-
   {
     page.width=612.0; // letter
     page.height=792.0;
@@ -55,6 +55,7 @@ ProcessingParameters()
   int jobId, numCopies;
   const char *user, *title; // will stay around
   bool fitplot;
+  bool fillprint;   //print-scaling = fill
   PageRect page;
   Rotation orientation,normal_landscape;  // normal_landscape (i.e. default direction) is e.g. needed for number-up=2
   bool paper_is_landscape;
@@ -107,6 +108,7 @@ class PDFTOPDF_PageHandle {
   // fscale:  inverse_scale (from nup, fitplot)
   virtual void add_border_rect(const PageRect &rect,BorderType border,float fscale) =0;
   // TODO?! add standalone crop(...) method (not only for subpages)
+  virtual Rotation crop(const PageRect &cropRect,Rotation orientation,Position xpos,Position ypos) =0;
   virtual void add_subpage(const std::shared_ptr<PDFTOPDF_PageHandle> &sub,float xpos,float ypos,float scale,const PageRect *crop=NULL) =0;
   virtual void mirror() =0;
   virtual void rotate(Rotation rot) =0;

--- a/filter/pdftopdf/qpdf_pdftopdf_processor.cc
+++ b/filter/pdftopdf/qpdf_pdftopdf_processor.cc
@@ -171,6 +171,65 @@ void QPDF_PDFTOPDF_PageHandle::add_border_rect(const PageRect &_rect,BorderType 
 #endif
 }
 // }}}
+/*
+ *  This crop function is written for print-scaling=fill option.
+ *  Trim Box is used for trimming the page in required size.
+ */
+Rotation QPDF_PDFTOPDF_PageHandle::crop(const PageRect &cropRect,Rotation orientation,Position xpos,Position ypos)
+{
+  page.assertInitialized();
+  if(orientation==ROT_0||orientation==ROT_180)
+    page.replaceOrRemoveKey("/Rotate",makeRotate(ROT_90));
+  else
+    page.replaceOrRemoveKey("/Rotate",makeRotate(ROT_0));
+
+  PageRect currpage= getBoxAsRect(getTrimBox(page));
+  double width = currpage.right-currpage.left;
+  double height = currpage.top-currpage.bottom;
+  double pageWidth = cropRect.right-cropRect.left;
+  double pageHeight = cropRect.top-cropRect.bottom;
+  double final_w,final_h;   //Width and height of cropped image.
+
+  Rotation pageRot = getRotate(page);
+  if(pageRot==ROT_0||pageRot==ROT_180)
+  {
+    std::swap(pageHeight,pageWidth);
+  }
+  if(width*pageHeight/pageWidth<=height)
+  {
+    final_w = width;
+    final_h = width*pageHeight/pageWidth;
+  }
+  else{
+    final_w = height*pageWidth/pageHeight;
+    final_h = height;
+  }
+
+  double posw = (width-final_w)/2,
+        posh = (height-final_h)/2;
+  // posw, posh : Position along width and height respectively.
+  // Calculating required position.  
+  if(xpos==Position::LEFT)        
+    posw =0;
+  else if(xpos==Position::RIGHT)
+    posw*=2;
+  
+  if(ypos==Position::TOP)
+    posh*=2;
+  else if(ypos==Position::BOTTOM)
+    posh=0;
+
+  // making PageRect for cropping.
+  currpage.left += posw;
+  currpage.bottom += posh;
+  currpage.top =currpage.bottom+final_h;
+  currpage.right=currpage.left+final_w;
+  //Cropping.
+  // TODO: Borders are covered by the image. buffer space?
+  page.replaceKey("/TrimBox",makeBox(currpage.left,currpage.bottom,currpage.right,currpage.top));
+  page.replaceOrRemoveKey("/Rotate",makeRotate(ROT_0));
+  return getRotate(page);
+}
 
 // TODO: better cropping
 // TODO: test/fix with qsub rotation

--- a/filter/pdftopdf/qpdf_pdftopdf_processor.cc
+++ b/filter/pdftopdf/qpdf_pdftopdf_processor.cc
@@ -174,8 +174,9 @@ void QPDF_PDFTOPDF_PageHandle::add_border_rect(const PageRect &_rect,BorderType 
 /*
  *  This crop function is written for print-scaling=fill option.
  *  Trim Box is used for trimming the page in required size.
+ *  scale tells if we need to scale input file.
  */
-Rotation QPDF_PDFTOPDF_PageHandle::crop(const PageRect &cropRect,Rotation orientation,Position xpos,Position ypos)
+Rotation QPDF_PDFTOPDF_PageHandle::crop(const PageRect &cropRect,Rotation orientation,Position xpos,Position ypos,bool scale)
 {
   page.assertInitialized();
   if(orientation==ROT_0||orientation==ROT_180)
@@ -195,16 +196,23 @@ Rotation QPDF_PDFTOPDF_PageHandle::crop(const PageRect &cropRect,Rotation orient
   {
     std::swap(pageHeight,pageWidth);
   }
-  if(width*pageHeight/pageWidth<=height)
+  if(scale)
   {
-    final_w = width;
-    final_h = width*pageHeight/pageWidth;
+    if(width*pageHeight/pageWidth<=height)
+    {
+      final_w = width;
+      final_h = width*pageHeight/pageWidth;
+    }
+    else{
+      final_w = height*pageWidth/pageHeight;
+      final_h = height;
+    }
   }
   else{
-    final_w = height*pageWidth/pageHeight;
-    final_h = height;
+    final_w = std::min(width,pageWidth);
+    final_h = std::min(height,pageHeight);
   }
-
+  fprintf(stderr,"After Cropping: %lf %lf %lf %lf\n",width,height,final_w,final_h);
   double posw = (width-final_w)/2,
         posh = (height-final_h)/2;
   // posw, posh : Position along width and height respectively.

--- a/filter/pdftopdf/qpdf_pdftopdf_processor.h
+++ b/filter/pdftopdf/qpdf_pdftopdf_processor.h
@@ -12,7 +12,7 @@ class QPDF_PDFTOPDF_PageHandle : public PDFTOPDF_PageHandle {
   virtual void mirror();
   virtual void rotate(Rotation rot);
   virtual void add_label(const PageRect &rect, const std::string label);
-
+  virtual Rotation crop(const PageRect &cropRect,Rotation orientation,Position xpos,Position ypos);
   void debug(const PageRect &rect,float xpos,float ypos);
  private:
   bool isExisting() const;

--- a/filter/pdftopdf/qpdf_pdftopdf_processor.h
+++ b/filter/pdftopdf/qpdf_pdftopdf_processor.h
@@ -12,7 +12,7 @@ class QPDF_PDFTOPDF_PageHandle : public PDFTOPDF_PageHandle {
   virtual void mirror();
   virtual void rotate(Rotation rot);
   virtual void add_label(const PageRect &rect, const std::string label);
-  virtual Rotation crop(const PageRect &cropRect,Rotation orientation,Position xpos,Position ypos);
+  virtual Rotation crop(const PageRect &cropRect,Rotation orientation,Position xpos,Position ypos,bool scale);
   void debug(const PageRect &rect,float xpos,float ypos);
  private:
   bool isExisting() const;


### PR DESCRIPTION
Related to #65 .

For this functionality, the input file has to cover the entire page. I first cropped input file according to the page's aspect ratio after that normal processing is done.
```imagetopdf``` and ```imagetoraster``` uses ```convert``` command(ImageMagick) to crop the input file.
```pdftopdf``` filter uses qpdf to crop the given pdf.
Is there any improvement that needs to be done in this PR?