### PR TITLE
Set orientation for crop-to-fit and fill in pdftopdf.

### DIFF
--- a/filter/pdftopdf/pdftopdf.cc
+++ b/filter/pdftopdf/pdftopdf.cc
@@ -369,6 +369,8 @@ void getParameters(ppd_file_t *ppd,int num_options,cups_option_t *options,Proces
       static const Rotation ipp2rot[4]={ROT_0, ROT_90, ROT_270, ROT_180};
       param.orientation=ipp2rot[ipprot-3];
     }
+  } else {
+    param.noOrientation = true;
   }
 
   ppd_size_t *pagesize;

--- a/filter/pdftopdf/pdftopdf_processor.cc
+++ b/filter/pdftopdf/pdftopdf_processor.cc
@@ -177,6 +177,12 @@ bool processPDFTOPDF(PDFTOPDF_Processor &proc,ProcessingParameters &param) // {{
 
   if(param.fillprint||param.cropfit){
     fprintf(stderr,"[DEBUG]: Cropping input pdf and Enabling fitplot.\n");
+    if(param.noOrientation&&pages.size())
+    {
+      bool land = pages[0]->is_landscape(param.orientation);
+      if(land)
+        param.orientation = param.normal_landscape;
+    }
     for(int i=0;i<(int)pages.size();i++)
     {
       std::shared_ptr<PDFTOPDF_PageHandle> page = pages[i];

--- a/filter/pdftopdf/pdftopdf_processor.h
+++ b/filter/pdftopdf/pdftopdf_processor.h
@@ -16,6 +16,7 @@ ProcessingParameters()
     fitplot(false),
     fillprint(false),  //print-scaling = fill
     cropfit(false),
+    noOrientation(false),
     orientation(ROT_0),normal_landscape(ROT_270),
     paper_is_landscape(false),
     duplex(false),
@@ -58,6 +59,7 @@ ProcessingParameters()
   bool fitplot;
   bool fillprint;   //print-scaling = fill
   bool cropfit;     // -o crop-to-fit
+  bool noOrientation;
   PageRect page;
   Rotation orientation,normal_landscape;  // normal_landscape (i.e. default direction) is e.g. needed for number-up=2
   bool paper_is_landscape;
@@ -111,6 +113,7 @@ class PDFTOPDF_PageHandle {
   virtual void add_border_rect(const PageRect &rect,BorderType border,float fscale) =0;
   // TODO?! add standalone crop(...) method (not only for subpages)
   virtual Rotation crop(const PageRect &cropRect,Rotation orientation,Position xpos,Position ypos,bool scale) =0;
+  virtual bool is_landscape(Rotation orientation) =0 ;
   virtual void add_subpage(const std::shared_ptr<PDFTOPDF_PageHandle> &sub,float xpos,float ypos,float scale,const PageRect *crop=NULL) =0;
   virtual void mirror() =0;
   virtual void rotate(Rotation rot) =0;

--- a/filter/pdftopdf/qpdf_pdftopdf_processor.cc
+++ b/filter/pdftopdf/qpdf_pdftopdf_processor.cc
@@ -239,6 +239,22 @@ Rotation QPDF_PDFTOPDF_PageHandle::crop(const PageRect &cropRect,Rotation orient
   return getRotate(page);
 }
 
+bool QPDF_PDFTOPDF_PageHandle::is_landscape(Rotation orientation)
+{
+  page.assertInitialized();
+  if(orientation==ROT_0||orientation==ROT_180)
+    page.replaceOrRemoveKey("/Rotate",makeRotate(ROT_90));
+  else
+    page.replaceOrRemoveKey("/Rotate",makeRotate(ROT_0));
+
+  PageRect currpage= getBoxAsRect(getTrimBox(page));
+  double width = currpage.right-currpage.left;
+  double height = currpage.top-currpage.bottom;
+  if(width>height)
+    return true;
+  return false;
+}
+
 // TODO: better cropping
 // TODO: test/fix with qsub rotation
 void QPDF_PDFTOPDF_PageHandle::add_subpage(const std::shared_ptr<PDFTOPDF_PageHandle> &sub,float xpos,float ypos,float scale,const PageRect *crop) // {{{

--- a/filter/pdftopdf/qpdf_pdftopdf_processor.h
+++ b/filter/pdftopdf/qpdf_pdftopdf_processor.h
@@ -13,6 +13,7 @@ class QPDF_PDFTOPDF_PageHandle : public PDFTOPDF_PageHandle {
   virtual void rotate(Rotation rot);
   virtual void add_label(const PageRect &rect, const std::string label);
   virtual Rotation crop(const PageRect &cropRect,Rotation orientation,Position xpos,Position ypos,bool scale);
+  virtual bool is_landscape(Rotation orientation);
   void debug(const PageRect &rect,float xpos,float ypos);
  private:
   bool isExisting() const;


### PR DESCRIPTION
Bug fix for #92. 
When the input format is other than "pdf"(like ps) and ```pdftopdf``` filter chain is being used then ```pdftopdf``` is unable to automatically set the orientation for crop-to-fit and fill options. When orientation is not set, the is_landscape function is used to check orientation of the input file.