### PR TITLE
Add checks for processing gif.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@ testdither
 testimage
 testrgb
 ttfread
+.vscode/

--- a/cupsfilters/image-gif.c
+++ b/cupsfilters/image-gif.c
@@ -126,7 +126,13 @@ _cupsImageReadGIF(
               transparent = buf[3];
           }
 
-          while (gif_get_block(fp, buf) != 0);
+          while (gif_get_block(fp, buf) != 0)
+          {
+            if(gif_eof)
+            {
+              return (-1);
+            }
+          }
           break;
 
       case ',' :	/* cupsImage data */
@@ -487,8 +493,11 @@ gif_read_image(FILE         *fp,	/* I - Input file */
     temp += bpp;
     if (xpos == img->xsize)
     {
-      _cupsImagePutRow(img, 0, ypos, img->xsize, pixels);
-
+      int res = _cupsImagePutRow(img, 0, ypos, img->xsize, pixels);
+      if(res)
+      {
+        return (-1);
+      }
       xpos = 0;
       temp = pixels;
 


### PR DESCRIPTION
Fixes #81. Fixes #82. Some checks are added so that program exits gracefully. Checks are added according to the input files given by @ocean1. Return type of flush_tile() function is changed to int.