### PR TITLE
cups-browsed: Fix broken trailing space removal on "NickName".

### DIFF
--- a/utils/cups-browsed.c
+++ b/utils/cups-browsed.c
@@ -5277,8 +5277,8 @@ gboolean update_cups_queues(gpointer unused) {
 	      memmove(ptr, prefix, strlen(prefix));
 	      ptr = line + strlen(line) - 1;
 	      while(isspace(*ptr) && ptr > line) {
-		ptr --;
 		*ptr = '\0';
+		ptr --;
 	      }
 	      if (*ptr != '"') {
 		if (ptr < line + sizeof(line) - 2) {


### PR DESCRIPTION
The code tried to remove trailing spaces, but if there was
at least one trailing space, the last two characters of the
line were removed. This caused removal of the quotation mark
in case exactly one trailing space was present, breaking
the PPD and subsequently causing CUPS to mess up all queues
(even local ones).

Signed-off-by: Oliver Freyermuth <o.freyermuth@googlemail.com>