### PR TITLE
filter/texttotext.c: link with libiconv if needed

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -778,7 +778,7 @@ texttotext_SOURCES = \
 	filter/texttotext.c
 EXTRA_texttotext_SOURCES = filter/strcasestr.c
 texttotext_CFLAGS = $(CUPS_CFLAGS)
-texttotext_LDADD = $(STRCASESTR) $(CUPS_LIBS)
+texttotext_LDADD = $(STRCASESTR) $(CUPS_LIBS) $(LIBICONV)
 texttotext_DEPENDENCIES = $(STRCASESTR)
 
 pdftops_SOURCES = \
@@ -1049,3 +1049,5 @@ if ENABLE_BRAILLE
 	$(RM) $(DESTDIR)$(pkgfilterdir)/vectortoubrl
 	$(RM) $(DESTDIR)$(pkgfilterdir)/textbrftoindexv4
 endif
+
+SUBDIRS =

--- a/autogen.sh
+++ b/autogen.sh
@@ -13,8 +13,19 @@ aclocal --version > /dev/null 2> /dev/null || {
     echo "error: aclocal not found"
     exit 1
 }
+
 automake --version > /dev/null 2> /dev/null || {
     echo "error: automake not found"
+    exit 1
+}
+
+autopoint --version > /dev/null 2> /dev/null || {
+    echo "error: autopoint not found"
+    exit 1
+}
+
+gettext --version > /dev/null 2> /dev/null || {
+    echo "error: gettext not found"
     exit 1
 }
 
@@ -39,6 +50,12 @@ fi
 
 rm -rf autom4te*.cache
 
+autopoint --force || {
+    echo "error: autopoint failed"
+    exit 1
+}
+# autopoint is for libiconv discovery; we don't want the po directory
+rm -rf po
 $LIBTOOLIZE --force --copy || {
     echo "error: libtoolize failed"
     exit 1

--- a/configure.ac
+++ b/configure.ac
@@ -18,7 +18,7 @@ AC_CONFIG_MACRO_DIR([m4])
 m4_include([m4/ac_define_dir.m4])
 m4_include([m4/ax_compare_version.m4])
 m4_include([m4/basic-directories.m4])
-AM_INIT_AUTOMAKE([1.11 gnu dist-xz dist-bzip2])
+AM_INIT_AUTOMAKE([1.11 gnu dist-xz dist-bzip2 subdir-objects])
 AM_SILENT_RULES([yes])
 AC_LANG([C++])
 AC_CONFIG_HEADERS([config.h])
@@ -54,12 +54,16 @@ AC_PROG_CC
 AC_PROG_CXX
 AX_CXX_COMPILE_STDCXX([11],[noext],[mandatory])
 AM_PROG_CC_C_O
+AM_ICONV
 AC_PROG_CPP
 AC_PROG_INSTALL
 AC_PROG_LN_S
 AC_PROG_MAKE_SET
 AC_PROG_LIBTOOL
 PKG_PROG_PKG_CONFIG([0.20])
+
+AM_GNU_GETTEXT_VERSION([0.18.3])
+AM_GNU_GETTEXT([external])
 
 # ========================================
 # Specify the fontdir patch if not default


### PR DESCRIPTION
texttotext.c uses iconv so it should link with libiconv on platforms
where it is a separate library (e.g. uClibc-ng without built-in NLS)
otherwise texttotext fails to link:

  CCLD     texttotext
[...]/ld: texttotext-texttotext.o: in function `main':
texttotext.c:(.text.startup+0xde0): undefined reference to `libiconv_open'
[...]/ld: texttotext.c:(.text.startup+0xf9d): undefined reference to `libiconv'
[...]/ld: texttotext.c:(.text.startup+0xfd6): undefined reference to `libiconv'
[...]/ld: texttotext.c:(.text.startup+0x16c3): undefined reference to `libiconv_close'

Modify autogen.sh to call autopoint, which adds the libiconv discovery.
It also creates a "po" skeleton but we can discard it, since it is not
really necessary.

Fixes: https://bugs.busybox.net/show_bug.cgi?id=12031

Signed-off-by: Carlos Santos <unixmania@gmail.com>