### PR TITLE
Build system: support autoreconf

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,6 +6,7 @@ pkgconf_DATA = \
 	libfontembed.pc
 
 doc_DATA = \
+	ABOUT-NLS \
 	AUTHORS \
 	COPYING \
 	NEWS \
@@ -15,6 +16,7 @@ doc_DATA = \
 EXTRA_DIST = \
 	$(doc_DATA) \
 	autogen.sh \
+	config.rpath \
 	libcupsfilters.pc.in \
 	libfontembed.pc.in \
 	utils/cups-browsed.service \


### PR DESCRIPTION
Some integration tools (e.g. Buildroot) run autoreconf to re-generate
the configure script. Ensure that the files config.rpath and ABOUT-NLS
are provided. They are required because we gettextized cups-filters to
detect libiconv.

Signed-off-by: Carlos Santos <unixmania@gmail.com>