### PR TITLE
Fix leaks in get-printer-attributes

### DIFF
--- a/utils/cups-browsed.c
+++ b/utils/cups-browsed.c
@@ -5805,6 +5805,7 @@ get_printer_attributes(const char* uri, int fallback_request,
           !strcmp(valuebuffer,"server-error-version-not-supported")){
 	  if (!fallback_request) {
 	    debug_printf("The server doesn't support IPP2.0 request, trying to IPP1.1 request\n");
+	    httpClose(http_printer);
 	    return get_printer_attributes(uri,1,pattrs,job_state_attributes, attr_size);
 	  }
         }
@@ -5816,9 +5817,11 @@ get_printer_attributes(const char* uri, int fallback_request,
      uri, cupsLastErrorString());
     if (!fallback_request) {
       debug_printf("Trying IPP1.1 Request\n");
+      httpClose(http_printer);
       return get_printer_attributes(uri,1,pattrs,job_state_attributes, attr_size);
     }
   }
+  httpClose(http_printer);
 
   return response;
 }


### PR DESCRIPTION
cups-browsed leaks http_t structure in get_printer_attributes().

Reported by valgrind:

==126994== 1,623,360 (1,593,264 direct, 30,096 indirect) bytes in 114 blocks are definitely lost in loss record 1,197 of 1,198                              
==126994==    at 0x483BB1A: calloc (vg_replace_malloc.c:762)                                                                                                
==126994==    by 0x4C5342E: http_create (http.c:3969)                                                                                                       
==126994==    by 0x4C5668C: httpConnect2 (http.c:446)                                                                                                       
==126994==    by 0x40AD68: httpConnectEncryptShortTimeout (cups-browsed.c:1166)                                                                             
==126994==    by 0x40AD68: get_printer_attributes (cups-browsed.c:5768)                                                                                     
==126994==    by 0x40B041: get_printer_attributes (cups-browsed.c:5819)                                                                                     
==126994==    by 0x4157E3: create_remote_printer_entry (cups-browsed.c:6925)                                                                                
==126994==    by 0x41A0A7: examine_discovered_printer_record (cups-browsed.c:9326)                                                                          
==126994==    by 0x41B5E4: found_cups_printer (cups-browsed.c:10093)
==126994==    by 0x41BF6E: browse_poll_get_printers (cups-browsed.c:10396)
==126994==    by 0x41BF6E: browse_poll (cups-browsed.c:10664)
==126994==    by 0x4B02DCA: g_idle_dispatch (gmain.c:5618)
==126994==    by 0x4B0649F: g_main_dispatch (gmain.c:3180)
==126994==    by 0x4B0649F: g_main_context_dispatch (gmain.c:3845)
==126994==    by 0x4B0682F: g_main_context_iterate.isra.0 (gmain.c:3918)
==126994== 
==126994== 1,751,601 (1,719,048 direct, 32,553 indirect) bytes in 123 blocks are definitely lost in loss record 1,198 of 1,198
==126994==    at 0x483BB1A: calloc (vg_replace_malloc.c:762)
==126994==    by 0x4C5342E: http_create (http.c:3969)
==126994==    by 0x4C5668C: httpConnect2 (http.c:446)
==126994==    by 0x40AD68: httpConnectEncryptShortTimeout (cups-browsed.c:1166)
==126994==    by 0x40AD68: get_printer_attributes (cups-browsed.c:5768)
==126994==    by 0x4157E3: create_remote_printer_entry (cups-browsed.c:6925)
==126994==    by 0x41A0A7: examine_discovered_printer_record (cups-browsed.c:9326)
==126994==    by 0x41B5E4: found_cups_printer (cups-browsed.c:10093)                           
==126994==    by 0x41BF6E: browse_poll_get_printers (cups-browsed.c:10396)                     
==126994==    by 0x41BF6E: browse_poll (cups-browsed.c:10664)                                  
==126994==    by 0x4B02DCA: g_idle_dispatch (gmain.c:5618)                                     
==126994==    by 0x4B0649F: g_main_dispatch (gmain.c:3180)                                     
==126994==    by 0x4B0649F: g_main_context_dispatch (gmain.c:3845)                             
==126994==    by 0x4B0682F: g_main_context_iterate.isra.0 (gmain.c:3918)                       
==126994==    by 0x4B06B22: g_main_loop_run (gmain.c:4112)

Those two are the biggest two leaks.