### PR TITLE
Epson ET-7700 does not support image/pwg-raster

### DIFF
--- a/cupsfilters/ppdgenerator.c
+++ b/cupsfilters/ppdgenerator.c
@@ -1868,7 +1868,9 @@ ppdCreateFromIPP2(char         *buffer,          /* I - Filename buffer */
     formatfound = 1;
     is_pdf = 1;
   }
-  if (cupsArrayFind(pdl_list, "image/pwg-raster")) {
+  /* Epson ET-7700 reports pwg-raster support in get-printer-attributes response, but it does
+     not support pwg-raster in reality - all jobs ends with */
+  if (cupsArrayFind(pdl_list, "image/pwg-raster") && strncmp(model, "ET-7700 Series", 14)) {
     if ((attr = ippFindAttribute(response,
 				 "pwg-raster-document-resolution-supported",
 				 IPP_TAG_RESOLUTION)) != NULL) {


### PR DESCRIPTION
Hi,

I have report in Fedora  - https://bugzilla.redhat.com/show_bug.cgi?id=1756726 - which is about Epson ET-7700 reports bad document format when image/pwg-raster format is used.
It seems the model does not support pwg-raster, but image/urf format works fine.

The patch is about crossing out that specific model from pwg-raster document format, so output ppd does not have the line for pwg-raster.

Would you mind adding it to the project?