### PR TITLE
cups-browsed: Fix unset location check to use DNS-SD field

### DIFF
--- a/utils/cups-browsed.c
+++ b/utils/cups-browsed.c
@@ -9089,7 +9089,7 @@ examine_discovered_printer_record(const char *host,
     }
   }
   /* Extract location from DNS-SD TXT record's "note" field */
-  if (!location) {
+  if (location[0] == '\0') {
     if (txt) {
       entry = avahi_string_list_find((AvahiStringList *)txt, "note");
       if (entry) {
@@ -9103,8 +9103,6 @@ examine_discovered_printer_record(const char *host,
         /* don't avahi_free(note_value) here! */
       }
     }
-    if (!location)
-      location = "";
   }
   /* A NULL location is only passed in from resolve_callback(), which is
      HAVE_AVAHI */


### PR DESCRIPTION
In `examine_discovered_printer_record`, the `location` parameter is ensured not to be `NULL`.  However, when checking whether to update the location from the DNS-SD TXT record note field, it is checked for being a `NULL` pointer.  Since all invocations seem to default to the empty string instead of `NULL`, the check is adjusted accordingly.