### PR TITLE
cups-browsed,implicitclass: Do fallback without mediacol

### DIFF
--- a/backend/implicitclass.c
+++ b/backend/implicitclass.c
@@ -307,7 +307,9 @@ main(int  argc,				/* I - Number of command-line args */
 
       /* Copying the argument to a new char** which will be sent to the filter
 	 and the ipp backend*/
-      for (i = 0; i < 5; i++)
+    argv_nt[0] = calloc(strlen(printer_uri) + 8, sizeof(char));
+    strcpy(argv_nt[0], printer_uri);
+      for (i = 1; i < 5; i++)
 	argv_nt[i] = argv[i];
 
       /* Few new options will be added to the argv[5]*/
@@ -367,8 +369,7 @@ main(int  argc,				/* I - Number of command-line args */
 	setenv("FINAL_CONTENT_TYPE", "application/pcl", 1);
 
       ippDelete(response);
-      strcpy(argv_nt[0], printer_uri);
-      fprintf(stderr, "Passing the following arguments to the implicitclass backend\n");
+      fprintf(stderr, "Passing the following arguments to the ipp backend\n");
        /*Arguments sent to the ipp backend*/
       for( i = 0; i < 7; i++){
          fprintf(stderr, "argv[%d]: %s\n",i,argv_nt[i]);

--- a/backend/implicitclass.c
+++ b/backend/implicitclass.c
@@ -323,6 +323,7 @@ main(int  argc,				/* I - Number of command-line args */
       set_option_in_str(argv_nt[5], outbuflen, "cups-browsed-dest-printer",NULL);
       set_option_in_str(argv_nt[5], outbuflen, "cups-browsed",NULL);
       setenv("DEVICE_URI",printer_uri, 1);
+      fprintf(stderr, "Setting the device uri to  %s\n",printer_uri);
       fprintf(stderr, "Changed the argv[5] to %s\n",argv_nt[5]);
 
       filefd = cupsTempFd(tempfile_filter, sizeof(tempfile_filter));
@@ -366,9 +367,16 @@ main(int  argc,				/* I - Number of command-line args */
 	setenv("FINAL_CONTENT_TYPE", "application/pcl", 1);
 
       ippDelete(response);
+      strcpy(argv_nt[0], printer_uri);
+      fprintf(stderr, "Passing the following arguments to the implicitclass backend\n");
+       /*Arguments sent to the ipp backend*/
+      for( i = 0; i < 7; i++){
+         fprintf(stderr, "argv[%d]: %s\n",i,argv_nt[i]);
+       }
 
       /* The implicitclass backend will send the job directly to the
 	 ipp backend*/
+
       pid_t pid = fork();
       if ( pid == 0 ) {
 	fprintf(stderr, "DEBUG: Started IPP Backend with pid: %d\n",getpid());


### PR DESCRIPTION
The fallback is required in three cases : 
1. Some printers doesn't support "media-col-database", so in that case we can do a IPP2.0 request without asking for media-col-database. In this case the ipp status returned is `IPP_STATUS_ERROR_BAD_REQUEST`.

2. Some printer doesn't support IPP2.0 and return error `IPP_STATUS_ERROR_VERSION_NOT_SUPPORTED`, so in this case we do a IPP1.1 request.

3. In some case, the ipp status is null, but still no information is returned from the printer, the printer only returns `attributes-natural-language` and `attribute charset`, in this case, we can do one of the above fallback to get better output.



*Implementation*
First we do a normal IPP 2.0 request with requested attributes {"all", "media-col-database"}, if it fails we do a IPP1.1 request, and if that also fails we do a request without asking for media-col-database.


*Testing*
1. Tested on a remote cups Queue where the cups version on the printer side was 2.2.10
2. Tested for legacy printer, where the cups version was 1.4.2
3. Tested for a IPP network printer supporting only IPP 1.1
4. Tested for a IPP network printer supporting IPP 2.0.
