### PR TITLE
foomatic-rip: fix compilation with -fno-common

### DIFF
--- a/filter/foomatic-rip/foomaticrip.c
+++ b/filter/foomatic-rip/foomaticrip.c
@@ -105,7 +105,7 @@ jobparams_t * get_current_job()
 }
 
 
-dstr_t *postpipe;  /* command into which the output of this filter should be piped */
+dstr_t *postpipe = NULL;  /* command into which the output of this filter should be piped */
 FILE *postpipe_fh = NULL;
 
 FILE * open_postpipe()

--- a/filter/foomatic-rip/options.c
+++ b/filter/foomatic-rip/options.c
@@ -38,14 +38,14 @@ typedef struct icc_mapping_entry_s {
 } icc_mapping_entry_t;
 
 /* Values from foomatic keywords in the ppd file */
-char printer_model [256];
+extern char printer_model [256];
 char printer_id [256];
 char driver [128];
 char cmd [4096];
 char cmd_pdf [4096];
-dstr_t *postpipe = NULL;  /* command into which the output of this
+extern dstr_t *postpipe;  /* command into which the output of this
                              filter should be piped */
-char cupsfilter [256];
+extern char cupsfilter [256];
 int jobentitymaxlen = 0;
 int userentitymaxlen = 0;
 int hostentitymaxlen = 0;


### PR DESCRIPTION
Starting from the upcoming GCC release 10, the default of -fcommon option will
change to -fno-common. This causes compilation errors in foomatic-rip. These
seem to be due to missing "external" declarations.

https://gcc.gnu.org/onlinedocs/gcc-9.2.0/gcc/Code-Gen-Options.html#index-fno-common