### PR TITLE
Prioritize print-color-mode-supported during creating Color Models

### DIFF
--- a/cupsfilters/ppdgenerator.c
+++ b/cupsfilters/ppdgenerator.c
@@ -2677,9 +2677,9 @@ ppdCreateFromIPP2(char         *buffer,          /* I - Filename buffer */
 
   if ((attr = ippFindAttribute(response, "urf-supported", IPP_TAG_KEYWORD)) ==
       NULL)
-    if ((attr = ippFindAttribute(response, "pwg-raster-document-type-supported",
+    if ((attr = ippFindAttribute(response, "print-color-mode-supported",
 				 IPP_TAG_KEYWORD)) == NULL)
-      if ((attr = ippFindAttribute(response, "print-color-mode-supported",
+      if ((attr = ippFindAttribute(response, "pwg-raster-document-type-supported",
 				   IPP_TAG_KEYWORD)) == NULL)
         attr = ippFindAttribute(response, "output-mode-supported",
 				IPP_TAG_KEYWORD);


### PR DESCRIPTION
over pwg-raster-document-type-supported

For #186 