### PR TITLE
pdftops: added handling of empty input

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -789,10 +789,17 @@ texttotext_DEPENDENCIES = $(STRCASESTR)
 pdftops_SOURCES = \
 	filter/common.c \
 	filter/common.h \
-	filter/pdftops.c
+	filter/pdftops.c \
+	filter/pdf.cxx \
+	filter/pdf.h
 EXTRA_pdftops_SOURCES = filter/strcasestr.c
-pdftops_CFLAGS = $(CUPS_CFLAGS)
-pdftops_LDADD = $(STRCASESTR) $(CUPS_LIBS)
+pdftops_CFLAGS = \
+	$(CUPS_CFLAGS) \
+	$(LIBQPDF_CFLAGS)
+pdftops_LDADD = \
+	$(STRCASESTR) \
+	$(CUPS_LIBS) \
+	$(LIBQPDF_LIBS)
 pdftops_DEPENDENCIES = $(STRCASESTR)
 
 pdftoraster_SOURCES = \

--- a/filter/pdf.cxx
+++ b/filter/pdf.cxx
@@ -84,6 +84,24 @@ extern "C" void pdf_free(pdf_t *pdf)
   delete pdf;
 }
 
+/*
+ * 'pdf_pages()' - Count number of pages in file
+ *                         using QPDF.
+ * I - Filename to open
+ * O - Number of pages or -1 on error
+ */
+int pdf_pages(const char *filename)
+{
+  QPDF *pdf = new QPDF();
+  try{
+  pdf->processFile(filename);
+  }catch(...) {
+    return -1;
+  }
+  int pages = (pdf->getAllPages()).size();
+  return pages;
+}
+
 
 /**
  * 'pdf_prepend_stream' - Prepend a stream to the contents of a specified

--- a/filter/pdf.h
+++ b/filter/pdf.h
@@ -45,6 +45,7 @@ void pdf_add_type1_font(pdf_t *doc, unsigned page, const char *name);
 void pdf_resize_page(pdf_t *doc, unsigned page, float width, float length, float *scale);
 void pdf_duplicate_page (pdf_t *doc, unsigned page, unsigned count);
 int pdf_fill_form(pdf_t *doc, opt_t *opt);
+int pdf_pages(const char *filename);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
pdftops filter exits with value 0 on empty input and zero page pdf and with value 1 on broken, damaged and wrong format input files and PS is considered a wrong format input for the pdftops filter to ensure similar behaviour for all filters accepting pdf as input.