### PR TITLE
Fix segfaults in test suite when test font is missing

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -788,6 +788,9 @@ AC_ARG_WITH([test-font-path],
 	[with_test_font_path="$withval"],
 	[with_test_font_path="/usr/share/fonts/dejavu/DejaVuSans.ttf"]
 )
+AC_CHECK_FILE("$with_test_font_path", [], [
+	AC_MSG_ERROR([Requested font file is missing. Please install a package providing it.])
+])
 AC_DEFINE_UNQUOTED([TESTFONT], ["$with_test_font_path"], [Path to font used in tests])
 
 # ================

--- a/filter/test_pdf2.c
+++ b/filter/test_pdf2.c
@@ -41,12 +41,18 @@ int main()
 
   // font, pt.1 
   const char *fn=TESTFONT;
+  OTF_FILE *otf=NULL;
 /*
   if (argc==2) {
     fn=argv[1];
   }
 */
-  OTF_FILE *otf=otf_load(fn);
+  otf=otf_load(fn);
+  if (!otf)
+  {
+    printf("Font %s was not loaded, exiting.\n", TESTFONT);
+    return 1;
+  }
   assert(otf);
   FONTFILE *ff=fontfile_open_sfnt(otf);
   EMB_PARAMS *emb=emb_new(ff,

--- a/fontembed/test_analyze.c
+++ b/fontembed/test_analyze.c
@@ -183,10 +183,17 @@ void show_hmtx(OTF_FILE *otf) // {{{
 int main(int argc,char **argv)
 {
   const char *fn=TESTFONT;
+  OTF_FILE *otf=NULL;
   if (argc==2) {
     fn=argv[1];
   }
-  OTF_FILE *otf=otf_load(fn);
+  otf=otf_load(fn);
+  if (!otf)
+  {
+    printf("Font %s was not loaded, exiting.\n", TESTFONT);
+    return 1;
+  }
+
   assert(otf);
   if (otf->numTTC) {
     printf("TTC has %d fonts, using %d\n",otf->numTTC,otf->useTTC);

--- a/fontembed/test_pdf.c
+++ b/fontembed/test_pdf.c
@@ -72,10 +72,16 @@ static inline void write_string(FILE *f,EMB_PARAMS *emb,const char *str) // {{{
 int main(int argc,char **argv)
 {
   const char *fn=TESTFONT;
+  OTF_FILE *otf=NULL;
   if (argc==2) {
     fn=argv[1];
   }
-  OTF_FILE *otf=otf_load(fn);
+  otf=otf_load(fn);
+  if (!otf)
+  {
+    printf("Font %s was not loaded, exiting.\n", TESTFONT);
+    return 1;
+  }
   assert(otf);
   FONTFILE *ff=fontfile_open_sfnt(otf);
   EMB_PARAMS *emb=emb_new(ff,

--- a/fontembed/test_ps.c
+++ b/fontembed/test_ps.c
@@ -45,10 +45,16 @@ static inline void write_string(FILE *f,EMB_PARAMS *emb,const char *str) // {{{
 int main(int argc,char **argv)
 {
   const char *fn=TESTFONT;
+  OTF_FILE *otf=NULL;
   if (argc==2) {
     fn=argv[1];
   }
-  OTF_FILE *otf=otf_load(fn);
+  otf=otf_load(fn);
+  if (!otf)
+  {
+    printf("Font %s was not loaded, exiting.\n", TESTFONT);
+    return 1;
+  }
   assert(otf);
   FONTFILE *ff=fontfile_open_sfnt(otf);
   EMB_PARAMS *emb=emb_new(ff,


### PR DESCRIPTION
Hi Till,

Font team in Fedora changed naming of fonts in Fedora, so now default test font in test suite is not found, but test binaries or configure script do not check if it exists and binaries segfault instead.

Old font path:
/usr/share/fonts/dejavu/DejaVuSans.ttf

New font path:
/usr/share/fonts/dejavu-sans-fonts/DejaVuSans.ttf

I'm not sure if the change will be in other distros, so I fixed it by supplying new path to configure script, but the segfault if the font is not supplied does not seem as correct result.

The pull request fixes the segfault and adds the check in configure.ac - the configuration will end with error if the font file is not found.

Would you mind adding it to the project?