### PR TITLE
cups-browsed: Added AllowResharingRemoteCUPSPrinters directive to cups-browsed

### DIFF
--- a/utils/cups-browsed.conf.5
+++ b/utils/cups-browsed.conf.5
@@ -468,6 +468,31 @@ this timeout if no further broadcast from the server happens.
 
 .fam T
 .fi
+The AllowResharingRemoteCUPSPrinters directive determines whether a
+print queue pointing to a remote CUPS queue will be re-shared to the
+local network or not. Since the queues generated using the BrowsePoll
+directive are also pointing to remote queues, they are also shared
+automatically if the following option is set. Default is not to share
+remote queues.
+.PP
+.nf
+.fam C
+        AllowResharingRemoteCUPSPrinters Yes
+
+.fam T
+.fi
+The NewBrowsePollQueuesShared directive determines whether a print
+queue for a newly discovered printer (discovered by the BrowsePoll directive)
+will be shared to the local network or not. This directive will only work
+if AllowResharingRemoteCUPSPrinters is set to yes. Default is
+not to share printers discovered using BrowsePoll.
+.PP
+.nf
+.fam C
+        NewBrowsePollQueuesShared Yes
+
+.fam T
+.fi
 Set OnlyUnsupportedByCUPS to "Yes" will make cups-browsed not create
 local queues for remote printers for which CUPS creates queues by
 itself.  These printers are printers advertised via DNS-SD and doing

--- a/utils/cups-browsed.conf.in
+++ b/utils/cups-browsed.conf.in
@@ -125,7 +125,6 @@ BrowseRemoteProtocols @BROWSEREMOTEPROTOCOLS@
 
 # BrowseTimeout 300
 
-
 # Filtering of remote printers by other properties than IP addresses
 # of their servers
 
@@ -436,6 +435,22 @@ BrowseRemoteProtocols @BROWSEREMOTEPROTOCOLS@
 # IPBasedDeviceURIs IPv4
 # IPBasedDeviceURIs IPv6
 
+# The AllowResharingRemoteCUPSPrinters directive determines whether a
+# print queue pointing to a remote CUPS queue will be re-shared to the
+# local network or not. Since the queues generated using the BrowsePoll
+# directive are also pointing to remote queues, they are also shared
+# automatically if the following option is set. Default is not to share
+# remote printers.
+
+# AllowResharingRemoteCUPSPrinters Yes
+
+# The NewBrowsePollQueuesShared directive determines whether a print
+# queue for a newly discovered printer (discovered by the BrowsePoll directive)
+# will be shared to the local network or not. This directive will only work
+# if AllowResharingRemoteCUPSPrinters is set to yes. Default is
+# not to share printers discovered using BrowsePoll.
+
+# NewBrowsePollQueuesShared Yes
 
 # Set CreateRemoteRawPrinterQueues to "Yes" to let cups-browsed also
 # create local queues pointing to remote raw CUPS queues. Normally,


### PR DESCRIPTION
Hi Till,

The directive `NewBrowsePollQueuesShared` which shares printers discovered by the browse poll directive is added in the method `browse_poll_get_printers` as here it was already being checked for printers discovered by BrowsePoll directive.
Kindly let me know if this patch requires any modifications.