### PR TITLE
driverless: Unlink temporary file

### DIFF
--- a/utils/driverless.c
+++ b/utils/driverless.c
@@ -548,7 +548,7 @@ generate_ppd (const char *uri)
   while ((bytes = read(fd, buffer, sizeof(buffer))) > 0)
     bytes = fwrite(buffer, 1, bytes, stdout);
   close(fd);
-  unlink(buffer);
+  unlink(ppdname);
 
   return 0;
   


### PR DESCRIPTION
The call to unlink(2) in "driverless" used the wrong variable,
triggering a silent failure (ENAMETOOLONG), and leaving a temporary file
behind.