### PR TITLE
Use -dSAFER gs option

### DIFF
--- a/filter/foomatic-rip/foomaticrip.c
+++ b/filter/foomatic-rip/foomaticrip.c
@@ -669,7 +669,7 @@ int print_file(const char *filename, int convert)
 		else
 		  snprintf(pdf2ps_cmd, CMDLINE_MAX,
 			   "gs -q -sstdout=%%stderr -sDEVICE=ps2write -sOutputFile=- "
-			   "-dBATCH -dNOPAUSE -dPARANOIDSAFER -dNOINTERPOLATE -dNOMEDIAATTRS -dShowAcroForm %s 2>/dev/null || "
+			   "-dBATCH -dNOPAUSE -dSAFER -dNOINTERPOLATE -dNOMEDIAATTRS -dShowAcroForm %s 2>/dev/null || "
 			   "pdftops -level2 -origpagesizes %s - 2>/dev/null",
 			   filename, filename);
 
@@ -1085,7 +1085,7 @@ int main(int argc, char** argv)
                 else
                   profile_arg[0] = '\0';
 
-                snprintf(gstoraster, sizeof(gstoraster), "gs -dQUIET -dDEBUG -dPARANOIDSAFER -dNOPAUSE -dBATCH -dNOINTERPOLATE -dNOMEDIAATTRS -sDEVICE=cups -dShowAcroForm %s -sOutputFile=- -", profile_arg);
+                snprintf(gstoraster, sizeof(gstoraster), "gs -dQUIET -dDEBUG -dSAFER -dNOPAUSE -dBATCH -dNOINTERPOLATE -dNOMEDIAATTRS -sDEVICE=cups -dShowAcroForm %s -sOutputFile=- -", profile_arg);
                 free(icc_profile);
             }
 

--- a/filter/foomatic-rip/pdf.c
+++ b/filter/foomatic-rip/pdf.c
@@ -140,7 +140,7 @@ static int pdf_extract_pages(char filename[PATH_MAX],
             snprintf(last_arg, 50, "-dLastPage=%d", last);
     }
 
-    snprintf(gscommand, CMDLINE_MAX, "%s -q -dNOPAUSE -dBATCH -dPARANOIDSAFER -dNOINTERPOLATE -dNOMEDIAATTRS"
+    snprintf(gscommand, CMDLINE_MAX, "%s -q -dNOPAUSE -dBATCH -dSAFER -dNOINTERPOLATE -dNOMEDIAATTRS"
 	     "-sDEVICE=pdfwrite -dShowAcroForm %s %s %s %s",
 	     gspath, filename_arg, first_arg, last_arg, pdffilename);
 

--- a/filter/foomatic-rip/renderer.c
+++ b/filter/foomatic-rip/renderer.c
@@ -42,7 +42,7 @@ int test_gs_output_redirection()
     int bytes;
 
     snprintf(gstestcommand, CMDLINE_MAX,
-	     "%s -dQUIET -dPARANOIDSAFER -dNOPAUSE "
+	     "%s -dQUIET -dSAFER -dNOPAUSE "
              "-dBATCH -dNOMEDIAATTRS -sDEVICE=ps2write -sstdout=%%stderr "
              "-sOutputFile=/dev/null -c '(hello\n) print flush' 2>&1", gspath);
 

--- a/filter/gstoraster.c
+++ b/filter/gstoraster.c
@@ -791,7 +791,7 @@ main (int argc, char **argv, char *envp[])
   cupsArrayAdd(gs_args, strdup(tmpstr));
   cupsArrayAdd(gs_args, strdup("-dQUIET"));
   /*cupsArrayAdd(gs_args, strdup("-dDEBUG"));*/
-  cupsArrayAdd(gs_args, strdup("-dPARANOIDSAFER"));
+  cupsArrayAdd(gs_args, strdup("-dSAFER"));
   cupsArrayAdd(gs_args, strdup("-dNOPAUSE"));
   cupsArrayAdd(gs_args, strdup("-dBATCH"));
   cupsArrayAdd(gs_args, strdup("-dNOINTERPOLATE"));

--- a/filter/pdftopdf/pdftopdf.cc
+++ b/filter/pdftopdf/pdftopdf.cc
@@ -1245,7 +1245,7 @@ int main(int argc,char **argv)
 	args = cupsArrayNew(NULL, NULL);
 	cupsArrayAdd(args, strdup(command));
 	cupsArrayAdd(args, strdup("-dQUIET"));
-	cupsArrayAdd(args, strdup("-dPARANOIDSAFER"));
+	cupsArrayAdd(args, strdup("-dSAFER"));
 	cupsArrayAdd(args, strdup("-dNOPAUSE"));
 	cupsArrayAdd(args, strdup("-dBATCH"));
 	cupsArrayAdd(args, strdup("-dNOINTERPOLATE"));


### PR DESCRIPTION
Hi Till,

I talked with Chris Lidell a week ago and he told me -dPARANOIDSAFER option, which cups-filters use, is the same as -dSAFER and -dPARANOIDSAFER is deprecated in ghostscript, so in my opinion we can move to use -dSAFER. There were some differences in the past - ~2007 - but it is no longer true for some time and now they provide the same functionality.

Would you mind adding the patch into the project?