### PR TITLE
Mention cups-filters in pdftops debug log

### DIFF
--- a/filter/pdftops.c
+++ b/filter/pdftops.c
@@ -919,7 +919,7 @@ main(int  argc,				/* I - Number of command-line args */
 	 pdf_argv[pdf_argc++] = (char *)"-optimizecolorspace"; */
       /* Issue a warning message when printing a grayscale job with Poppler */
       fprintf(stderr, "WARNING: Grayscale/monochrome printing requested for this job but Poppler is not able to convert to grayscale/monochrome PostScript.\n");
-      fprintf(stderr, "WARNING: Use \"pdftops-renderer\" option (see README file) to use Ghostscript or MuPDF for the PDF -> PostScript conversion.\n");
+      fprintf(stderr, "WARNING: Use \"pdftops-renderer\" option (see cups-filters README file) to use Ghostscript or MuPDF for the PDF -> PostScript conversion.\n");
     }
     pdf_argv[pdf_argc++] = filename;
     pdf_argv[pdf_argc++] = (char *)"-";


### PR DESCRIPTION
Hi Till,

there is a report https://github.com/apple/cups/issues/5765 which led me to this pull request. In my opinion it would be good to mention the README debug log speaks of is cups-filters README, not CUPS - even when the log appears to be in CUPS logs.

Would you mind adding the patch to the project?