### PR TITLE
Do not pass NULL to fprintf()

### DIFF
--- a/filter/gstoraster.c
+++ b/filter/gstoraster.c
@@ -639,7 +639,7 @@ main (int argc, char **argv, char *envp[])
     goto out;
   }
   fprintf(stderr, "DEBUG: OUTFORMAT=\"%s\", so output format will be %s\n",
-	  outformat_env,
+	  (outformat_env ? outformat_env : "<none>"),
 	  (outformat == OUTPUT_FORMAT_RASTER ? "CUPS/PWG Raster" :
 	   (outformat == OUTPUT_FORMAT_PDF ? "PDF" :
 	    "PCL XL")));

--- a/filter/rastertopdf.cpp
+++ b/filter/rastertopdf.cpp
@@ -1343,7 +1343,8 @@ int main(int argc, char **argv)
     outformat = OUTPUT_FORMAT_PDF;
 #endif
     fprintf(stderr, "DEBUG: OUTFORMAT=\"%s\", output format will be %s\n",
-	    outformat_env, (outformat == OUTPUT_FORMAT_PDF ? "PDF" : "PCLM"));
+	    (outformat_env ? outformat_env : "<none>"),
+	    (outformat == OUTPUT_FORMAT_PDF ? "PDF" : "PCLM"));
   
     num_options = cupsParseOptions(argv[5], 0, &options);  
 


### PR DESCRIPTION
Passing NULL to printf-family of functions is undefined
behaviour. OpenBSD has detection mechanism for occurrences
of such condition. On my machine I get following messages
in syslog, while printing:

vfprintf %s NULL in "DEBUG: OUTFORMAT="%s", so output format will be %s "

Changes in this diff make those messages go away.