### PR TITLE
[RFE] Check for driverless support and set device-info accordingly

### DIFF
--- a/cupsfilters/ipp.h
+++ b/cupsfilters/ipp.h
@@ -42,6 +42,23 @@ char get_printer_attributes_log[LOGSIZE];
 
 const char     *resolve_uri(const char *raw_uri);
 #ifdef HAVE_CUPS_1_6
+                                /* Enum of possible driverless options */
+enum driverless_support_modes {
+  DRVLESS_CHECKERR,             /* Unable to get get-printer-attributes response*/
+  FULL_DRVLESS,                 /* Standard IPP Everywhere support, works with 'everywhere' model */
+  DRVLESS_IPP11,                /* Driverless support via IPP 1.1 request */
+  DRVLESS_INCOMPLETEIPP         /* Driverless support without media-col-database attribute */
+};
+
+/* Array of text strings explaining available driverless support */
+const char * driverless_support_strs[] = {
+  "driverless - cannot check driverless status",
+  "fully driverless",
+  "driverless via IPP 1.1",
+  "driverless with incomplete IPP request"
+};
+
+int check_driverless_support(const char* uri);
 ipp_t   *get_printer_attributes(const char* raw_uri,
 				const char* const pattrs[],
 				int pattrs_size,
@@ -55,6 +72,14 @@ ipp_t   *get_printer_attributes2(http_t *http_printer,
 				 const char* const req_attrs[],
 				 int req_attrs_size,
 				 int debug);
+ipp_t   *get_printer_attributes3(http_t *http_printer,
+				 const char* raw_uri,
+				 const char* const pattrs[],
+				 int pattrs_size,
+				 const char* const req_attrs[],
+				 int req_attrs_size,
+				 int debug,
+				 int* driverless_support);
 #endif /* HAVE_CUPS_1_6 */
 
 #  ifdef __cplusplus


### PR DESCRIPTION
Hi,

I encountered this problem several times during debugging printing issues with older printers - the device is capable to advertise itself via Avahi but its IPP response is not enough for CUPS temporary queue, either if it does not support IPP 2.0 or it's missing some required attributes.

Fortunately those printers can be driverless with help of cups-browsed, which has those two fallbacks available so even older IPP printers can be supported as driverless.

The problem is when you run 'sudo lpinfo -l -v', driverless backend says 'driverless' in device-info text - but it indicates only the device is available on avahi-browse, because driverless backend calls ippfind tool for the job and it just checks Avahi.
So you don't know (until you try to install it with 'everywhere' model) if the device is capable of being CUPS temporary queue or if cups-browsed is needed for working.

The patch is about propagation of info which fallback was used during get-printer-attributes request (called during running driverless backend) and it sets the part of device-info string about driverless to one of following 4 strings:
1) 'driverless - cannot check driverless status' - when get-printer-attributes fails
2) 'fully driverless' - device supports IPP standard ippeve
3) 'driverless via IPP1.1' - device supports IPP 1.1 get-printer-attributes
4) 'driverless with incomplete IPP request' - device supports get-printer-attributes without media-col-database

I tested it with my fully driverless HP LaserJet and with Canon printer of my colleague, which has incomplete IPP request. I wrote a basic sanity test for driverless backend in the past and it passes too.

What do you think about it? Is it a usable for the project? Please let me know if I should change something.

Thank you in advance!