### PR TITLE
Map two-sided-short-edge to DuplexTumble

### DIFF
--- a/filter/foomatic-rip/foomaticrip.c
+++ b/filter/foomatic-rip/foomaticrip.c
@@ -401,7 +401,7 @@ void process_cmdline_options()
                             if ((opt2 = find_option("Binding")))
                                 option_set_value(opt2, optset, "ShortEdge");
                             else
-                                option_set_value(opt, optset, "DuplexNoTumble");
+                                option_set_value(opt, optset, "DuplexTumble");
                         }
                     }
                 }


### PR DESCRIPTION
two-sided-short-edge and two-sided-long-edge were both mapped to
DuplexNoTumble.  DuplexNoTumble should be mapped to the long-edge
tumble and short-edge to DuplexTumble.