### PR TITLE
Update Generic-PDF_Printer-PDF.ppd

### DIFF
--- a/ppd/Generic-PDF_Printer-PDF.ppd
+++ b/ppd/Generic-PDF_Printer-PDF.ppd
@@ -147,6 +147,13 @@
 *Duplex DuplexTumble/Short-Edge binding: "@PJL SET DUPLEX=ON<0A>@PJL SET BINDING=SHORTEDGE<0A>"
 *JCLCloseUI: *Duplex
 
+*JCLOpenUI *ColorModel/Color: PickOne
+*OrderDependency: 100 JCLSetup *ColorModel
+*DefaultColorModel: color
+*ColorModel color/Color: "@PJL SET RENDERMODE=COLOR<0A>"
+*ColorModel grayscale/Black and White: "@PJL SET RENDERMODE=GRAYSCALE<0A>"
+*JCLCloseUI: *ColorModel
+
 *JCLOpenUI *Resolution/Resolution: PickOne
 *OrderDependency: 100 JCLSetup *Resolution
 *DefaultResolution: 600dpi


### PR DESCRIPTION
Hi,

Here is a patch  for Generic PDF PPD to enable color/gray scale printing switching.  Original Generic PPD has no color switch, therefore users cannot make black and white printing with color printers.

It adds a PJL RENDERMODE command to PDF print job.  When choosing "Black and White", the printout will be in gray scale (rendered in gray scale by printers), even if PDF is made as color document.
Of course it cannot print in color if the original document is made in black and white or the printer is not color capable :)

I checked it worked with Chrome Browser on Ubuntu as well as on ChromeOS.

Regards,