### PR TITLE
cups-browsed.8: Remove mentions of README and AUTHORS files

### DIFF
--- a/utils/cups-browsed.8
+++ b/utils/cups-browsed.8
@@ -96,12 +96,8 @@ that clients running cups 1.6.x plus \fBcups-browsed\fP can use the CUPS
 broadcasts from servers with cups 1.5.x. As with browsing of Bonjour
 broadcasts, the created local raw queues are available to applications
 and command line tools.
+.PP
+This manual page was written for the Debian Project, but it may be used by others.
 .SH SEE ALSO
 
 \fBcups-browsed.conf\fP(5)
-.PP
-/usr/share/doc/\fBcups-browsed\fP/README.gz
-.SH AUTHOR
-The authors of \fBcups-browsed\fP are listed in /usr/share/doc/\fBcups-browsed\fP/AUTHORS.
-.PP
-This manual page was written for the Debian Project, but it may be used by others.


### PR DESCRIPTION
Hi,

man page of cups-browsed mentions the absolute path to README and AUTHORS files, which can be different due packaging the project.
Currently, I have a downstream patch in Fedora for renaming the path and Ubuntu seems to duplicate README, NEWS, copyright files to both packages - cups-browsed and cups-filters - just into different dirs, which seems unnecessary for doc files.

In my opinion it would be the best just to remove the misleading entries from cups-browsed man page and stop duplicating files/stop carrying a downstream patch. The doc files will be available once in main location, /usr/share/doc/cups-filters.

Would it be okay?