### PR TITLE
modified when to call cupsGetNamedDest()

### DIFF
--- a/utils/cups-browsed.c
+++ b/utils/cups-browsed.c
@@ -7833,10 +7833,10 @@ gboolean update_cups_queues(gpointer unused) {
         else {
           debug_printf ("CUPS queue with URI %s found, but with \"printer-name\" %s", uri, ippGetString(attr, 0, NULL));
         }
+
+        ippDelete(response);
       }
 
-      ippDelete(response);
-   
       if (dest) {
 	/* CUPS has found a queue with this name.
 	   Either CUPS generates a temporary queue here or we have already

--- a/utils/cups-browsed.c
+++ b/utils/cups-browsed.c
@@ -7807,7 +7807,35 @@ gboolean update_cups_queues(gpointer unused) {
 #ifdef HAVE_CUPS_1_6
       /* Check whether there is a temporary CUPS queue which we would
          overwrite */
-      dest = cupsGetNamedDest(http, p->queue_name, NULL);
+      ipp_t *response =  NULL;
+      const char const *pattrs[] =
+                {
+                  "printer-name"
+                };
+
+      const char const *req_attrs[] =
+                {
+                  "printer-name"
+                };
+
+      if ((response = 
+           get_printer_attributes2(http, uri, 
+                       pattrs, 1, req_attrs, 1, 0)) == NULL) {
+        debug_printf ("No CUPS queue with URI %s found\n", uri);
+      }
+      else {
+        attr = ippFindAttribute(response, "printer-name", IPP_TAG_NAME);
+        if(!strcmp(ippGetString(attr, 0, NULL), p->queue_name)){
+          dest = cupsGetNamedDest(http, p->queue_name, NULL);
+          debug_printf ("CUPS queue %s with URI %s found", p->queue_name, uri);
+        }
+        else {
+          debug_printf ("CUPS queue with URI %s found, but with \"printer-name\" %s", uri, ippGetString(attr, 0, NULL));
+        }
+      }
+
+      ippDelete(response);
+   
       if (dest) {
 	/* CUPS has found a queue with this name.
 	   Either CUPS generates a temporary queue here or we have already

--- a/utils/cups-browsed.c
+++ b/utils/cups-browsed.c
@@ -7807,6 +7807,7 @@ gboolean update_cups_queues(gpointer unused) {
 #ifdef HAVE_CUPS_1_6
       /* Check whether there is a temporary CUPS queue which we would
          overwrite */
+      dest = NULL;
       ipp_t *response =  NULL;
       const char const *pattrs[] =
                 {


### PR DESCRIPTION
This PR modifies when to call cupsGetNamedDest(). 
Now instead of calling cupsGetNamedDest() for every printer , we first do a get-printer-attribute IPP request on local cupsd and check if we have CUPS queue with that name. If found then we call cupsGetNamedDest().