### PR TITLE
Mark the temp queue as cups-browsed during setting printer-is-shared

### DIFF
--- a/utils/cups-browsed.c
+++ b/utils/cups-browsed.c
@@ -7920,6 +7920,7 @@ gboolean update_cups_queues(gpointer unused) {
 	    num_options = cupsAddOption("printer-is-shared",
 					(i == 0 ? "true" : "false"),
 					num_options, &options);
+	    num_options = cupsAddOption(CUPS_BROWSED_MARK "-default", "true", num_options, &options);
 	    cupsEncodeOptions2(request, num_options, options,
 			       IPP_TAG_OPERATION);
 	    cupsEncodeOptions2(request, num_options, options, IPP_TAG_PRINTER);


### PR DESCRIPTION
Hi,

the patch is connected to what we discussed in #241  - to have gnome-settings-daemon ignoring cups-browsed queues.

In case of temp queues, cups-browsed is setting/resetting printer-is-shared attribute to make them permanent. The problem is, cups is generating 'printer-added' notification during the operation, and gnome-settings-daemon catches it and generates pop-up notification.

The solution is to add ```cups-browsed``` option to the print queue during setting/resetting printer-is-shared attribute. 
IMO it will not cause a regression, since the option is applied only on successful request to cups, mid-way state (one request passes, the other fails) will end up as error either way, and cups is prone of duplicate options, there is no chance of two ```cups-browsed``` options if both ```cupsAddOption``` is applied.

Would you mind adding the patch to the project? Please tell me if I should change something.

P.S. The original temp queue mechanism in cups-browsed doesn't work right now due #245 . The temp queue is replaced by a permanent queue without setting/resetting printer-is-shared attribute.