### PR TITLE
[WIP] configure.ac: Add configure option for keeping created queues during shutdown

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -840,6 +840,30 @@ PKG_CHECK_EXISTS([liblouis], [
 AM_CONDITIONAL(ENABLE_BRAILLE, test "x$enable_braille" = xyes)
 AC_SUBST(TABLESDIR)
 
+# =========================================
+# Local queue naming for remote CUPS queues
+# =========================================
+AC_ARG_WITH([remote-cups-local-queue-naming],
+	[AS_HELP_STRING([--with-remote-cups-local-queue-naming=DNS-SD|MakeModel|RemoteName], [Choose the origin of local queue naming for remote CUPS queues, default based on DNS-SD ID])],
+	[case "x$withval" in
+		"xDNS-SD")
+			REMOTE_CUPS_LOCAL_QUEUE_NAMING="DNS-SD"
+			;;
+		"xMakeModel")
+			REMOTE_CUPS_LOCAL_QUEUE_NAMING="MakeModel"
+			;;
+		"xRemoteName")
+			REMOTE_CUPS_LOCAL_QUEUE_NAMING="RemoteName"
+			;;
+		*)
+			REMOTE_CUPS_LOCAL_QUEUE_NAMING="DNS-SD"
+			;;
+	esac],
+	[REMOTE_CUPS_LOCAL_QUEUE_NAMING="DNS-SD"]
+)
+
+AC_SUBST(REMOTE_CUPS_LOCAL_QUEUE_NAMING)
+
 # =========================================================
 # Select a different shell instead of the default /bin/bash
 # =========================================================
@@ -909,43 +933,44 @@ AC_OUTPUT
 AC_MSG_NOTICE([
 ==============================================================================
 Environment settings:
-	CFLAGS:          ${CFLAGS}
-	CXXFLAGS:        ${CXXFLAGS}
-	LDFLAGS:         ${LDFLAGS}
+	CFLAGS:                                    ${CFLAGS}
+	CXXFLAGS:                                  ${CXXFLAGS}
+	LDFLAGS:                                   ${LDFLAGS}
 Build configuration:
-	cups-config:     ${with_cups_config}
-	font directory:  ${sysconfdir}/${FONTDIR}
-	foomatic:        ${enable_foomatic}
-	init directory:  ${INITDDIR}
-	cups dom socket: ${CUPS_DEFAULT_DOMAINSOCKET}
-	poppler:         ${enable_poppler}
-	ghostscript:     ${enable_ghostscript}
-	gs-path:         ${with_gs_path}
-	mutool:          ${enable_mutool}
-	mutool-path:     ${with_mutool_path}
-	ippfind-path:    ${with_ippfind_path}
-	imagefilters:    ${enable_imagefilters}
-	jpeg:            ${with_jpeg}
-	pdftocairo-path: ${with_pdftocairo_path}
-	pdftops:         ${with_pdftops}
-	pdftops-path:    ${with_pdftops_path}
-	png:             ${with_png}
-	php:             ${with_php}
-	php-config:      ${with_php_config}
-	shell:           ${with_shell}
-	test-font:       ${with_test_font_path}
-	tiff:            ${with_tiff}
-	avahi:           ${enable_avahi}
-	dbus:            ${enable_dbus}
-	browsing:        ${with_browseremoteprotocols}
-	werror:          ${enable_werror}
-	braille:	 ${enable_braille}
-	braille tables:  ${TABLESDIR}
-	driverless:      ${enable_driverless}
-	apple-raster:    ${APPLE_RASTER_FILTER}
-	pclm:            ${enable_pclm}
-	all ipp printer auto-setup: ${enable_auto_setup_all}
-	only driverless auto-setup: ${enable_auto_setup_driverless_only}
-	only local auto-setup: ${enable_auto_setup_local_only}
+	cups-config:                               ${with_cups_config}
+	font directory:                            ${sysconfdir}/${FONTDIR}
+	foomatic:                                  ${enable_foomatic}
+	init directory:                            ${INITDDIR}
+	cups dom socket:                           ${CUPS_DEFAULT_DOMAINSOCKET}
+	poppler:                                   ${enable_poppler}
+	ghostscript:                               ${enable_ghostscript}
+	gs-path:                                   ${with_gs_path}
+	mutool:                                    ${enable_mutool}
+	mutool-path:                               ${with_mutool_path}
+	ippfind-path:                              ${with_ippfind_path}
+	imagefilters:                              ${enable_imagefilters}
+	jpeg:                                      ${with_jpeg}
+	pdftocairo-path:                           ${with_pdftocairo_path}
+	pdftops:                                   ${with_pdftops}
+	pdftops-path:                              ${with_pdftops_path}
+	png:                                       ${with_png}
+	php:                                       ${with_php}
+	php-config:                                ${with_php_config}
+	shell:                                     ${with_shell}
+	test-font:                                 ${with_test_font_path}
+	tiff:                                      ${with_tiff}
+	avahi:                                     ${enable_avahi}
+	dbus:                                      ${enable_dbus}
+	browsing:                                  ${with_browseremoteprotocols}
+	werror:                                    ${enable_werror}
+	braille:                                   ${enable_braille}
+	braille tables:                            ${TABLESDIR}
+	driverless:                                ${enable_driverless}
+	apple-raster:                              ${APPLE_RASTER_FILTER}
+	pclm:                                      ${enable_pclm}
+	local queue naming for remote CUPS queues: ${REMOTE_CUPS_LOCAL_QUEUE_NAMING}
+	all ipp printer auto-setup:                ${enable_auto_setup_all}
+	only driverless auto-setup:                ${enable_auto_setup_driverless_only}
+	only local auto-setup:                     ${enable_auto_setup_local_only}
 ==============================================================================
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -840,6 +840,14 @@ PKG_CHECK_EXISTS([liblouis], [
 AM_CONDITIONAL(ENABLE_BRAILLE, test "x$enable_braille" = xyes)
 AC_SUBST(TABLESDIR)
 
+# ===============================================
+# Should we keep generated queues after shutdown?
+# ===============================================
+AC_ARG_ENABLE(saving-created-queues, AS_HELP_STRING([--enable-saving-created-queues], [enable saving created queues during shutdown]),
+	      SAVING_CREATED_QUEUES=$enableval,SAVING_CREATED_QUEUES=no)
+
+AC_SUBST(SAVING_CREATED_QUEUES)
+
 # =========================================
 # Local queue naming for remote CUPS queues
 # =========================================
@@ -969,6 +977,7 @@ Build configuration:
 	apple-raster:                              ${APPLE_RASTER_FILTER}
 	pclm:                                      ${enable_pclm}
 	local queue naming for remote CUPS queues: ${REMOTE_CUPS_LOCAL_QUEUE_NAMING}
+	keep generated queues during shutdown:     ${SAVING_CREATED_QUEUES}
 	all ipp printer auto-setup:                ${enable_auto_setup_all}
 	only driverless auto-setup:                ${enable_auto_setup_driverless_only}
 	only local auto-setup:                     ${enable_auto_setup_local_only}

--- a/utils/cups-browsed.conf.in
+++ b/utils/cups-browsed.conf.in
@@ -570,7 +570,7 @@ LocalQueueNamingRemoteCUPS @REMOTE_CUPS_LOCAL_QUEUE_NAMING@
 # re-creation of the queues when cups-browsed is restarted, which
 # often causes a clutter of CUPS notifications on the desktop.
 
-# KeepGeneratedQueuesOnShutdown No
+KeepGeneratedQueuesOnShutdown @SAVING_CREATED_QUEUES@
 
 # If there is more than one remote CUPS printer whose local queue
 # would get the same name and AutoClustering is set to "Yes" (the

--- a/utils/cups-browsed.conf.in
+++ b/utils/cups-browsed.conf.in
@@ -390,6 +390,9 @@ BrowseRemoteProtocols @BROWSEREMOTEPROTOCOLS@
 # LocalQueueNamingRemoteCUPS DNS-SD
 # LocalQueueNamingRemoteCUPS MakeModel
 # LocalQueueNamingRemoteCUPS RemoteName
+
+LocalQueueNamingRemoteCUPS @REMOTE_CUPS_LOCAL_QUEUE_NAMING@
+
 # LocalQueueNamingIPPPrinter DNS-SD
 # LocalQueueNamingIPPPrinter MakeModel
 


### PR DESCRIPTION
Hi Till,

there is another pull request mentioned in https://github.com/OpenPrinting/cups-filters/issues/241#issuecomment-641413728 .

It introduces an option --enable-saving-created-queues, which sets the default value for KeepGeneratedQueuesOnShutdown in cups-browsed.conf. The default is 'no'.