### PR TITLE
configure.ac: fix cross-compilation without dejavu

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -796,10 +796,10 @@ AC_ARG_WITH([test-font-path],
 	[with_test_font_path=`find /usr/share/fonts -name DejaVuSans.ttf || echo /usr/share/fonts/dejavu/DejaVuSans.ttf`]
 )
 
-AS_IF([test -f "$with_test_font_path"],
-	[AC_DEFINE_UNQUOTED([TESTFONT], ["$with_test_font_path"], [Path to font used in tests])],
+AS_IF([test "x$cross_compiling" != "xyes" && ! test -f "$with_test_font_path"],
 	[AC_MSG_ERROR(DejaVuSans.ttf font file is missing. Please install a package providing it.)]
 )
+AC_DEFINE_UNQUOTED([TESTFONT], ["$with_test_font_path"], [Path to font used in tests])
 
 # ================
 # Check for cflags


### PR DESCRIPTION
Cross-compilation is broken since commit 1d66106. Indeed, when
cross-compiling, dejavu font won't be installed in /usr/share/fonts. The
path (e.g. $(TARGET_DIR)/usr/share/fonts/dejavu/DejaVuSans.ttf) could be
provided through --with-test-font-path which will fix the build failure
but will result in broken test programs.

So when cross-compiling don't try to check if the test-font-path is
valid or not and just use the one provided by the user or the default
one (e.g. /usr/share/fonts/dejavu/DejaVuSans.ttf)

Fix #262

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>