### PR TITLE
changes in cups-browsed.c file to produce back-up file for debug logging

### DIFF
--- a/utils/cups-browsed.c
+++ b/utils/cups-browsed.c
@@ -711,9 +711,19 @@ long int findLogFileSize()
 }
 
 void copyToFile(FILE **fp1, FILE **fp2){
-  char ch;
-  while((ch = getc(*fp1)) != EOF)
-    putc(ch, *fp2);
+  int buffer_size = 2048;
+  char *buf = (char*) malloc(sizeof(char)*buffer_size);
+  if(!buf){
+    fprintf(stderr,"Error creating buffer for debug logging\n");
+    return;
+  }
+  fseek(*fp1, 0, SEEK_SET);
+  size_t r = fread(buf, sizeof(char), sizeof(buffer_size)-1, *fp1);
+  while(r == sizeof(buffer_size)-1){
+    fwrite(buf, sizeof(char), sizeof(buffer_size)-1, *fp2);
+    r = fread(buf, sizeof(char), sizeof(buffer_size)-1, *fp1);
+  }
+  fwrite(buf, sizeof(char), r, *fp2);
 }
 
 void

--- a/utils/cups-browsed.c
+++ b/utils/cups-browsed.c
@@ -154,7 +154,6 @@ static int  ldap_rebind_proc(LDAP *RebindLDAPHandle,
 #define SAVE_OPTIONS_FILE "/cups-browsed-options-%s"
 #define DEBUG_LOG_FILE "/cups-browsed_log"
 #define DEBUG_LOG_FILE_2 "/cups-browsed_previous_logs"
-#define MAX_LOG_SIZE 30
 
 /* Status of remote printer */
 typedef enum printer_status_e {
@@ -434,6 +433,7 @@ static uint16_t BrowsePort = 631;
 static browsepoll_t **BrowsePoll = NULL;
 static unsigned int NewBrowsePollQueuesShared = 0;
 static unsigned int AllowResharingRemoteCUPSPrinters = 0;
+static unsigned int DebugLogFileSize = 30;
 static size_t NumBrowsePoll = 0;
 static guint update_netifs_sourceid = 0;
 static char local_server_str[1024];
@@ -714,8 +714,6 @@ void copyToFile(FILE **fp1, FILE **fp2){
   char ch;
   while((ch = getc(*fp1)) != EOF)
     putc(ch, *fp2);
-  fclose(*fp1);
-  fclose(*fp2);
 }
 
 void
@@ -742,11 +740,13 @@ debug_printf(const char *format, ...) {
     }
 
     long int log_file_size = findLogFileSize(); 
-    if(log_file_size>(long int)MAX_LOG_SIZE*1024){
+    if(log_file_size>(long int)DebugLogFileSize*1024){
       fclose(lfp);
       FILE *fp1 = fopen(debug_log_file, "r");
       FILE *fp2 = fopen(debug_log_file_bckp, "w");
       copyToFile(&fp1,&fp2);
+      fclose(fp1);
+      fclose(fp2);
       lfp = fopen(debug_log_file, "w");
     }
 }

--- a/utils/cups-browsed.conf.5
+++ b/utils/cups-browsed.conf.5
@@ -970,10 +970,10 @@ without jobs.
 
 .fam T
 .fi
-The DebugLogFileSize defines the maximum size possible (in KBytes)
+DebugLogFileSize defines the maximum size possible (in KBytes)
 of the log files (cups-browsed_log and cups-browsed_previous_logs)
 that is created using cups-browsed in the debugging mode.
-Keeping its value to 0 would turn off any restriction
+Setting its value to 0 would turn off any restriction
 on the size of the file.
 .PP
 .nf

--- a/utils/cups-browsed.conf.5
+++ b/utils/cups-browsed.conf.5
@@ -970,6 +970,16 @@ without jobs.
 
 .fam T
 .fi
+The MAX_LOG_SIZE defines the maximum size possible (in KBytes)
+of the log files (cups-browsed_log and cups-browsed_previous_logs)
+that is created using cups-browsed in the debugging mode.
+.PP
+.nf
+.fam C
+        DebugLogFileSize 30
+
+.fam T
+.fi
 The AutoShutdownTimeout directive specifies after how many seconds
 without local raw queues set up pointing to any discovered remote
 printers or jobs on these queues cups-browsed should actually shut

--- a/utils/cups-browsed.conf.5
+++ b/utils/cups-browsed.conf.5
@@ -970,13 +970,15 @@ without jobs.
 
 .fam T
 .fi
-The MAX_LOG_SIZE defines the maximum size possible (in KBytes)
+The DebugLogFileSize defines the maximum size possible (in KBytes)
 of the log files (cups-browsed_log and cups-browsed_previous_logs)
 that is created using cups-browsed in the debugging mode.
+Keeping its value to 0 would turn off any restriction
+on the size of the file.
 .PP
 .nf
 .fam C
-        DebugLogFileSize 30
+        DebugLogFileSize 300
 
 .fam T
 .fi

--- a/utils/cups-browsed.conf.in
+++ b/utils/cups-browsed.conf.in
@@ -758,3 +758,9 @@ BrowseRemoteProtocols @BROWSEREMOTEPROTOCOLS@
 # shutdown.
 
 # AutoShutdownTimeout 30
+
+# The MAX_LOG_SIZE defines the maximum size possible (in KBytes)
+# of the log files (cups-browsed_log and cups-browsed_previous_logs)
+# that is created using cups-browsed in the debugging mode.
+
+# DebugLogFileSize 30

--- a/utils/cups-browsed.conf.in
+++ b/utils/cups-browsed.conf.in
@@ -759,10 +759,10 @@ BrowseRemoteProtocols @BROWSEREMOTEPROTOCOLS@
 
 # AutoShutdownTimeout 30
 
-# The DebugLogFileSize defines the maximum size possible (in KBytes)
+# DebugLogFileSize defines the maximum size possible (in KBytes)
 # of the log files (cups-browsed_log and cups-browsed_previous_logs)
 # that is created using cups-browsed in the debugging mode.
-# Keeping its value to 0 would turn off any restriction
+# Setting its value to 0 would turn off any restriction
 # on the size of the file.
 
 # DebugLogFileSize 300

--- a/utils/cups-browsed.conf.in
+++ b/utils/cups-browsed.conf.in
@@ -759,8 +759,10 @@ BrowseRemoteProtocols @BROWSEREMOTEPROTOCOLS@
 
 # AutoShutdownTimeout 30
 
-# The MAX_LOG_SIZE defines the maximum size possible (in KBytes)
+# The DebugLogFileSize defines the maximum size possible (in KBytes)
 # of the log files (cups-browsed_log and cups-browsed_previous_logs)
 # that is created using cups-browsed in the debugging mode.
+# Keeping its value to 0 would turn off any restriction
+# on the size of the file.
 
-# DebugLogFileSize 30
+# DebugLogFileSize 300


### PR DESCRIPTION
Currently debug logging was not checking for the size of the debug file it has produced. The amount of logging could go to huge extents and cause issues such as filling up entire disk if proper control of file is taken care of.
Adding two log files which alternate between them helps to resolve the issue in 2 ways:
- Does not create mulitple backup logs which may, again, cause the disk to be full of logs.
- Does not allow the size of the cups-browsed_log to go beyond a particular size which can be set in the source code file.

Fixes #260 