### PR TITLE
Updating driverless

### DIFF
--- a/utils/driverless.c
+++ b/utils/driverless.c
@@ -46,10 +46,8 @@ static void		cancel_job(int sig);
 static int				
 compare_service_uri(char *a,	char *b)		
 {
-  size_t size_a = strlen(a);
-  size_t size_b = strlen(b);
-  size_t size = (size_a>size_b ? size_b+1 :size_a +1);
-  return (memcmp(a,b, size));
+  
+  return (strcmp(a,b));
 }
 void 
 listPrintersInArray(int post_proc_pipe[], cups_array_t *service_uri_list_ipps,  int reg_type_no, int mode){
@@ -335,7 +333,17 @@ listPrintersInArray(int post_proc_pipe[], cups_array_t *service_uri_list_ipps,  
 	    else{
 	  /* Call without arguments and env variable "SOFTWARE" starting
 	     with "CUPS" (Backend in discovery mode) */
-        printf("network %s \"%s\" \"%s (%s)\" \"%s\" \"\"\n", copy_service_uri_ipps, make_and_model, make_and_model, driverless_info, device_id);
+        if(reg_type_no < 1){
+          if(cupsArrayFind(service_uri_list_ipps,copy_service_uri_ipps) == NULL){
+        /* IPPS version of IPP printer is not present */
+          printf("network %s \"%s\" \"%s (%s)\" \"%s\" \"\"\n", service_uri, make_and_model, make_and_model, driverless_info, device_id);
+          }
+        }
+        else{
+        cupsArrayAdd(service_uri_list_ipps , service_uri);
+        printf("network %s \"%s\" \"%s (%s)\" \"%s\" \"\"\n", service_uri, make_and_model, make_and_model, driverless_info, device_id);
+        }
+        
       }
 
      read_error:
@@ -773,6 +781,7 @@ int main(int argc, char*argv[]) {
   if ((val = getenv("SOFTWARE")) != NULL &&
       strncasecmp(val, "CUPS", 4) == 0) {
     /* CUPS backend in discovery mode */
+    debug = 1;
     exit(list_printers(2,reg_type_no));
   } else{
     /* Manual call */

--- a/utils/driverless.c
+++ b/utils/driverless.c
@@ -46,7 +46,9 @@ static void		cancel_job(int sig);
 static int				
 compare_service_uri(char *a,	char *b)		
 {
-  size_t size = sizeof(a);
+  size_t size_a = strlen(a);
+  size_t size_b = strlen(b);
+  size_t size = (size_a>size_b ? size_b+1 :size_a +1);
   return (memcmp(a,b, size));
 }
 void 
@@ -55,11 +57,8 @@ listPrintersInArray(int post_proc_pipe[], cups_array_t *service_uri_list_ipps,  
         bytes;			/* Bytes copied */
         
   char	buffer[8192],		/* Copy buffer */
-        *bufferOutput, /*  service_uri along with metadata  */
-        * copy_bufferOutput_ipps;  /*  ipps scheme version of service_uri along with metadata  */
-  cups_file_t	*fp;			/* Post-processing input file */
-  char	*ptr;			/* Pointer into string */
-  char  *scheme = NULL,
+        *ptr,		/* Pointer into string */
+        *scheme = NULL,
         *copy_scheme_ipps = NULL, /*  ipps scheme version for ipp printers */
         *service_name = NULL,
         *domain = NULL,
@@ -81,8 +80,7 @@ listPrintersInArray(int post_proc_pipe[], cups_array_t *service_uri_list_ipps,  
 		    pdl[256],		/* PDL */
 		    driverless_info[256],	/* Driverless info string */
 		    device_id[2048];	/* 1284 device ID */
-  
-        
+  cups_file_t	*fp;			/* Post-processing input file */ 
   dup2(post_proc_pipe[0], 0);
   close(post_proc_pipe[0]);
   close(post_proc_pipe[1]);
@@ -94,8 +92,6 @@ listPrintersInArray(int post_proc_pipe[], cups_array_t *service_uri_list_ipps,  
     /* Mark all the fields of the output of ippfind */
     service_uri = (char *)malloc(2048*(sizeof(char)));
     copy_service_uri_ipps = (char *)malloc(2048*(sizeof(char)));
-    bufferOutput = (char *)malloc(8192*(sizeof(char)));
-    copy_bufferOutput_ipps = (char *)malloc(8192*(sizeof(char)));
 
     ptr = buffer;
     /* First, build the DNS-SD-service-name-based URI ... */
@@ -151,6 +147,7 @@ listPrintersInArray(int post_proc_pipe[], cups_array_t *service_uri_list_ipps,  
 		  copy_scheme_ipps, NULL,
 		  copy_service_host_name_ipps, 0, "/");
     }
+    
    
     /* ... second, complete the output line, either URI-only or with
 	  extra info for CUPS */
@@ -332,42 +329,13 @@ listPrintersInArray(int post_proc_pipe[], cups_array_t *service_uri_list_ipps,  
 
 	    if (mode == 1){
 	      /* Call with "list" argument  (PPD generator in list mode)   */ 
-        snprintf(bufferOutput,8191,"\"driverless:%s\" en \"%s\" \"%s, %s, cups-filters " VERSION
-            "\" \"%s\"\n", service_uri, make, make_and_model, driverless_info, device_id);  
-        bufferOutput[8191] = '\0';
-        if(reg_type_no < 1){
-          snprintf(copy_bufferOutput_ipps,8191,"\"driverless:%s\" en \"%s\" \"%s, %s, cups-filters " VERSION
-            "\" \"%s\"\n", copy_service_uri_ipps, make, make_and_model, driverless_info, device_id);
-          copy_bufferOutput_ipps[8191] = '\0';
-          if(cupsArrayFind(service_uri_list_ipps,copy_bufferOutput_ipps) == NULL){
-            /* IPPS version of IPP printer is not present */
-            printf("%s",bufferOutput);
-          }
-        }
-        else{
-         
-          cupsArrayAdd(service_uri_list_ipps , bufferOutput);
-          printf("%s",bufferOutput);
-        }
+        printf("\"driverless:%s\" en \"%s\" \"%s, %s, cups-filters " VERSION
+            "\" \"%s\"\n", service_uri, make, make_and_model, driverless_info, device_id);
       }
 	    else{
 	  /* Call without arguments and env variable "SOFTWARE" starting
 	     with "CUPS" (Backend in discovery mode) */
-       snprintf(bufferOutput,8191,"network %s \"%s\" \"%s (%s)\" \"%s\" \"\"\n", service_uri, make_and_model, make_and_model, driverless_info, device_id);
-       bufferOutput[8191] = '\0';
-        if(reg_type_no < 1){
-          snprintf(bufferOutput,8191,"network %s \"%s\" \"%s (%s)\" \"%s\" \"\"\n", copy_service_uri_ipps, make_and_model, make_and_model, driverless_info, device_id);
-          copy_bufferOutput_ipps[8191] = '\0';
-          if(cupsArrayFind(service_uri_list_ipps,copy_bufferOutput_ipps) == NULL){
-             /* IPPS version of IPP printer is not present */
-            printf("%s",bufferOutput);
-          }
-        }
-        else{
-          cupsArrayAdd(service_uri_list_ipps , bufferOutput);
-          printf("%s",bufferOutput);
-        }
-      
+        printf("network %s \"%s\" \"%s (%s)\" \"%s\" \"\"\n", copy_service_uri_ipps, make_and_model, make_and_model, driverless_info, device_id);
       }
 
      read_error:
@@ -764,11 +732,9 @@ int main(int argc, char*argv[]) {
 	exit(list_printers(1,reg_type_no));
       } else if (!strcasecmp(argv[i], "_ipps._tcp")) {
 	/* reg_type_no = 2 for IPPS entries only*/
-	debug = 1;
 	reg_type_no = 2;
       }else if (!strcasecmp(argv[i], "_ipp._tcp")) {
 	/* reg_type_no = 0 for IPP entries only*/
-	debug = 1;
 	reg_type_no = 0;
       }else if (!strncasecmp(argv[i], "cat", 3)) {
 	/* Generate the PPD file for the given driver URI */
@@ -807,11 +773,9 @@ int main(int argc, char*argv[]) {
   if ((val = getenv("SOFTWARE")) != NULL &&
       strncasecmp(val, "CUPS", 4) == 0) {
     /* CUPS backend in discovery mode */
-    debug = 1;
     exit(list_printers(2,reg_type_no));
   } else{
     /* Manual call */
-    debug = 1;
     exit(list_printers(0,reg_type_no));
   }
 


### PR DESCRIPTION
Testing results:
```
nidhi@nidhi-X510UNR:~$ driverless _ipps._tcp
ipps://HP%20OfficeJet%20Pro%206960%20%5BC3B82D%5D._ipps._tcp.local/
ipps://hello1._ipps._tcp.local/

nidhi@nidhi-X510UNR:~$ driverless _ipp._tcp
ipp://HP%20OfficeJet%20Pro%206960%20%5BC3B82D%5D%20(USB%201)._ipp._tcp.local/
ipp://hello1._ipp._tcp.local/
ipp://HP%20OfficeJet%20Pro%206960%20%5BC3B82D%5D._ipp._tcp.local/

nidhi@nidhi-X510UNR:~$ driverless 
ipps://HP%20OfficeJet%20Pro%206960%20%5BC3B82D%5D._ipps._tcp.local/
ipps://hello1._ipps._tcp.local/
ipp://HP%20OfficeJet%20Pro%206960%20%5BC3B82D%5D%20(USB%201)._ipp._tcp.local/

nidhi@nidhi-X510UNR:~$ driverless list
DEBUG: Started ippfind (PID 24180)
"driverless:ipps://HP%20OfficeJet%20Pro%206960%20%5BC3B82D%5D._ipps._tcp.local/" en "HP" "HP OfficeJet Pro 6960, fully driverless, cups-filters 1.27.5" "MFG:HP;MDL:OfficeJet Pro 6960;CMD:PCLM,PCL,PWGRaster,AppleRaster,JPEG,URF,PWG;"
"driverless:ipps://hello1._ipps._tcp.local/" en "Example" "Example Printer, fully driverless, cups-filters 1.27.5" "MFG:Example;MDL:Printer;CMD:PWGRaster,AppleRaster,PWG,URF;"
DEBUG: Started ippfind (PID 24184)
"driverless:ipp://HP%20OfficeJet%20Pro%206960%20%5BC3B82D%5D._ipp._tcp.local/" en "HP" "HP OfficeJet Pro 6960, fully driverless, cups-filters 1.27.5" "MFG:HP;MDL:OfficeJet Pro 6960;CMD:PCLM,PCL,PWGRaster,AppleRaster,JPEG,URF,PWG;"
"driverless:ipp://HP%20OfficeJet%20Pro%206960%20%5BC3B82D%5D%20(USB%201)._ipp._tcp.local/" en "HP" "HP OfficeJet Pro 6960, fully driverless, cups-filters 1.27.5" "MFG:HP;MDL:OfficeJet Pro 6960;CMD:PCLM,PCL,PWGRaster,AppleRaster,JPEG,URF,PWG;"
"driverless:ipp://hello1._ipp._tcp.local/" en "Example" "Example Printer, fully driverless, cups-filters 1.27.5" "MFG:Example;MDL:Printer;CMD:PWGRaster,AppleRaster,PWG,URF;"
DEBUG: PID 24180 (ippfind _ipps._tcp) exited with no errors.
DEBUG: PID 24184 (ippfind _ipp._tcp) exited with no errors.
```