### PR TITLE
[branch 1.x] driverless-fax: don't use a fixed path

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -22,6 +22,7 @@ EXTRA_DIST = \
 	libfontembed.pc.in \
 	utils/cups-browsed.service \
 	utils/cups-browsed-upstart.conf \
+	utils/driverless-fax.in \
 	filter/braille/drivers/index/ubrlto4dot.c \
 	filter/braille/filters/TODO.txt
 
@@ -93,6 +94,11 @@ cups_brf_SOURCES = \
 # ==============
 # PPD Generators
 # ==============
+utils/driverless-fax: utils/driverless-fax.in Makefile
+	sed \
+	  -e "s|\@CUPS_SERVERBIN\@|$(CUPS_SERVERBIN)|" \
+	  $< >$@
+
 pkgppdgendir = $(CUPS_SERVERBIN)/driver
 driverlessfaxscripts = \
 	utils/driverless-fax

--- a/utils/driverless-fax.in
+++ b/utils/driverless-fax.in
@@ -10,11 +10,11 @@
 #
 
 if [ $# -eq "0" ]; then
-    DEVICE_TYPE=FAX /usr/lib/cups/backend/driverless
+    DEVICE_TYPE=FAX @CUPS_SERVERBIN@/backend/driverless
     elif [ $# -eq "1" ]; then
-        DEVICE_TYPE=FAX /usr/lib/cups/driver/driverless "$1"
+        DEVICE_TYPE=FAX @CUPS_SERVERBIN@/driver/driverless "$1"
     elif [ $# -eq "2" ]; then
-        DEVICE_TYPE=FAX /usr/lib/cups/driver/driverless "$1" "$2"
+        DEVICE_TYPE=FAX @CUPS_SERVERBIN@/driver/driverless "$1" "$2"
     else
         echo "ERROR: Too many arguments"
 fi


### PR DESCRIPTION
Hi,

```driverless-fax``` wrapper uses a fixed path to ```driverless```, which is a problem on distros which don't put CUPS stuff into ```/usr/lib/cups``` (IIRC archlinux puts it into ```/usr/libexec/cups```).
The patch renames the wrapper to {name}.in and uses ```@CUPS_SERVERBIN@``` macro, which will be substituted during compilation for the real path.

Would you mind adding the patch? I'll create an extra pull request for master too.