### PR TITLE
driverless: Fix uninitialized buffer and parsing ippfind output

### DIFF
--- a/cupsfilters/ipp.h
+++ b/cupsfilters/ipp.h
@@ -38,6 +38,9 @@ extern "C" {
 #endif
 
 #define LOGSIZE 4 * 65536
+#define MAX_OUTPUT_LEN 8192
+#define MAX_URI_LEN 2048
+
 char get_printer_attributes_log[LOGSIZE];
 
 const char     *resolve_uri(const char *raw_uri);


### PR DESCRIPTION
See #308 .