### PR TITLE
cups-browsed.c: uuid was used after its pointer was freed by ippDelete()

### DIFF
--- a/utils/cups-browsed.c
+++ b/utils/cups-browsed.c
@@ -3614,7 +3614,7 @@ new_local_printer (const char *device_uri,
 {
   local_printer_t *printer = g_malloc (sizeof (local_printer_t));
   printer->device_uri = strdup (device_uri);
-  printer->uuid = (uuid ? strdup (uuid) : NULL);
+  printer->uuid = uuid;
   printer->cups_browsed_controlled = cups_browsed_controlled;
   return printer;
 }
@@ -3796,7 +3796,7 @@ get_printer_uuid(http_t *http_printer,
 
 
   if (attr)
-    uuid = ippGetString(attr, 0, NULL) + 9;
+    uuid = strdup(ippGetString(attr, 0, NULL) + 9);
   else {
     debug_printf ("Printer with URI %s: Cannot read \"printer-uuid\" IPP attribute!\n",
 		  raw_uri);


### PR DESCRIPTION
Hi,

valgrind [results](https://bugzilla.redhat.com/attachment.cgi?id=1717802) in Fedora [bug](https://bugzilla.redhat.com/show_bug.cgi?id=1881365) revealed that I didn't understand how ```ippFindAttribute()``` works when I issued a PR which clears ```response``` variable in ```get_printer_uuid()```. The ```ippFindAttribute()``` returns a pointer to a member of ```response``` structure and this pointer is freed when ```response``` is freed with ```ippDelete()```.

The fix now uses ```strdup()``` for the pointer and this copy is returned as return value.