### PR TITLE
foomatic-rip: remove tempfile created during pdf-to-ps conversion

### DIFF
--- a/filter/foomatic-rip/foomaticrip.c
+++ b/filter/foomatic-rip/foomaticrip.c
@@ -560,7 +560,7 @@ int print_file(const char *filename, int convert)
 {
     FILE *file;
     char buf[8192];
-    char tmpfilename[PATH_MAX];
+    char tmpfilename[PATH_MAX] = "";
     int type;
     int startpos;
     int pagecount;
@@ -688,6 +688,10 @@ int print_file(const char *filename, int convert)
                   fclose(in);
                 if (out != NULL)
                   fclose(out);
+
+                // Delete temp file if we created one
+                if ( *tmpfilename )
+                    unlink(tmpfilename);
 
                 return ret;
             }


### PR DESCRIPTION
print_file() foomatic-rip doesn't clean up the temporary file created when reading from stdin and a pdf-to-ps conversion is necessary.  The result is that `/var/spool/cups/tmp` can fill up very quickly on a busy system.

This should fix that.