### PR TITLE
Fix foomatic-rip infinite loop and file input

### DIFF
--- a/filter/foomatic-rip/foomaticrip.c
+++ b/filter/foomatic-rip/foomaticrip.c
@@ -1153,7 +1153,18 @@ int main(int argc, char** argv)
                when there is no postpipe) */
             _log("Raw printing, executing \"cat %%s\"\n\n");
             snprintf(tmp, 1024, "cat %s", postpipe->data);
+            if (strcasecmp(filename, "<STDIN>")) {
+              FILE *fh = fopen(filename, "r");
+              if (!fh) {
+                _log("Failed to open \"%s\".\n", filename);
+                fclose(stdin);
+              } else {
+                dup2(fileno(fh), 0);
+                fclose(fh);
+              }
+            }
             run_system_process("raw-printer", tmp);
+            filename = strtok_r(NULL, " ", &p);
             continue;
         }
 


### PR DESCRIPTION
If the foomatic rip command is not present in the PPD file, the foomatic
rip filter runs cat by default to forward stdin to stdout. However,
if input is provided through a file instead of stdin, then this file
needs to be dup'd to stdin for the command to work properly.

Also, the next file needs to be selected each time an input file is
processed by calling strok_r in order to prevent an infinite loop.

TEST=foomatic-rip --ppd=ppd.ppd file.pdf