### PR TITLE
Various browsed issues

### DIFF
--- a/cupsfilters/ppdgenerator.c
+++ b/cupsfilters/ppdgenerator.c
@@ -1059,9 +1059,11 @@ ippResolutionListToArray(ipp_attribute_t *attr)
       res_array = resolutionArrayNew();
       if (res_array) {
 	for (i = 0; i < count; i ++)
-	  if ((res = ippResolutionToRes(attr, i)) != NULL &&
-	      cupsArrayFind(res_array, res) == NULL)
-	    cupsArrayAdd(res_array, res);
+	  if ((res = ippResolutionToRes(attr, i)) != NULL) {
+	    if (cupsArrayFind(res_array, res) == NULL)
+	      cupsArrayAdd(res_array, res);
+	    free_resolution(res, NULL);
+	  }
       }
       if (cupsArrayCount(res_array) == 0) {
 	cupsArrayDelete(res_array);

--- a/cupsfilters/ppdgenerator.c
+++ b/cupsfilters/ppdgenerator.c
@@ -2353,8 +2353,6 @@ ppdCreateFromIPP2(char         *buffer,          /* I - Filename buffer */
 		     twidth, tlength);
     }
 
-    cupsArrayDelete(sizes);
-
    /*
     * Custom size support...
     */
@@ -2393,7 +2391,6 @@ ppdCreateFromIPP2(char         *buffer,          /* I - Filename buffer */
       cupsFilePuts(fp, "*CustomPageSize True: \"pop pop pop <</PageSize[5 -2 roll]/ImagingBBox null>>setpagedevice\"\n");
     }
   } else {
-    cupsArrayDelete(sizes);
     cupsFilePrintf(fp,
 		   "*%% Printer did not supply page size info via IPP, using defaults\n"
 		   "*OpenUI *PageSize/Media Size: PickOne\n"
@@ -2459,6 +2456,8 @@ ppdCreateFromIPP2(char         *buffer,          /* I - Filename buffer */
 		   "*PaperDimension EnvDL/Envelope DL: \"312 624\"\n"
 		   "*PaperDimension EnvMonarch/Envelope Monarch: \"279 540\"\n");
   }
+
+  cupsArrayDelete(printer_sizes);
 
  /*
   * InputSlot...

--- a/cupsfilters/ppdgenerator.h
+++ b/cupsfilters/ppdgenerator.h
@@ -71,6 +71,7 @@ char            *ppdCreateFromIPP2(char *buffer, size_t bufsize,
 				   const char *default_cluster_color);
 int             compare_resolutions(void *resolution_a, void *resolution_b,
 				    void *user_data);
+void            free_resolution(void *resolution, void *user_data);
 res_t *         ippResolutionToRes(ipp_attribute_t *attr, int index);
 cups_array_t *  resolutionArrayNew();
 cups_array_t*   generate_sizes(ipp_t *response,

--- a/cupsfilters/ppdgenerator.h
+++ b/cupsfilters/ppdgenerator.h
@@ -73,6 +73,7 @@ int             compare_resolutions(void *resolution_a, void *resolution_b,
 				    void *user_data);
 void            free_resolution(void *resolution, void *user_data);
 res_t *         ippResolutionToRes(ipp_attribute_t *attr, int index);
+res_t *         resolutionNew(int x, int y);
 cups_array_t *  resolutionArrayNew();
 cups_array_t*   generate_sizes(ipp_t *response,
 			       ipp_attribute_t **defattr,

--- a/utils/cups-browsed.c
+++ b/utils/cups-browsed.c
@@ -3079,6 +3079,8 @@ void get_cluster_default_attributes(ipp_t** merged_attributes,
 				     temp->media_source, temp->media_type);
     ippSetCollection(*merged_attributes, &media_col_default, 0, current_media);
 
+    free(temp->media_source);
+    free(temp->media_type);
     free(temp);
   }
 

--- a/utils/cups-browsed.c
+++ b/utils/cups-browsed.c
@@ -6410,13 +6410,14 @@ on_job_state (CupsNotifier *object,
 	      }
 	      break;
 	    }
+
+	    ippDelete(response);
+	    response = NULL;
+
 	    if (pstate == IPP_PRINTER_IDLE && paccept) {
 	      q->last_printer = i;
 	      break;
 	    }
-
-	    ippDelete(response);
-            response = NULL;
 	  } else
 	    debug_printf("IPP request to %s:%d failed.\n", p->host,
 			 p->port);

--- a/utils/cups-browsed.c
+++ b/utils/cups-browsed.c
@@ -8155,6 +8155,7 @@ gboolean update_cups_queues(gpointer unused) {
 	  sizes = NULL;
 	} else {
 	  make_model = (char*)malloc(sizeof(char) * 256);
+	  printer_attributes = get_cluster_attributes(p->queue_name);
 	  if ((attr = ippFindAttribute(printer_attributes,
 				       "printer-make-and-model",
 				       IPP_TAG_TEXT)) != NULL)
@@ -8172,7 +8173,6 @@ gboolean update_cups_queues(gpointer unused) {
 	    }
 	  }
 	  default_pagesize = (char *)malloc(sizeof(char)*32);
-	  printer_attributes = get_cluster_attributes(p->queue_name);
 	  debug_printf("Generated Merged Attributes for local queue %s\n",
 		       p->queue_name);
 	  conflicts = generate_cluster_conflicts(p->queue_name,
@@ -8321,6 +8321,7 @@ gboolean update_cups_queues(gpointer unused) {
 	    sizes = NULL;
 	  } else {
 	    make_model = (char*)malloc(sizeof(char)*256);
+	    printer_attributes = get_cluster_attributes(p->queue_name);
 	    if((attr = ippFindAttribute(printer_attributes,
 					"printer-make-and-model",
 					IPP_TAG_TEXT)) != NULL)
@@ -8338,7 +8339,6 @@ gboolean update_cups_queues(gpointer unused) {
 	      }
 	    }
 	    default_pagesize = (char *)malloc(sizeof(char)*32);
-	    printer_attributes = get_cluster_attributes(p->queue_name);
 	    debug_printf("Generated Merged Attributes for local queue %s\n",
 			 p->queue_name);
 	    conflicts = generate_cluster_conflicts(p->queue_name,

--- a/utils/cups-browsed.c
+++ b/utils/cups-browsed.c
@@ -6597,7 +6597,10 @@ on_job_state (CupsNotifier *object,
       cupsEncodeOptions2(request, num_options, options, IPP_TAG_OPERATION);
       cupsEncodeOptions2(request, num_options, options, IPP_TAG_PRINTER);
       ippDelete(cupsDoRequest(conn, request, "/admin/"));
+
       cupsFreeOptions(num_options, options);
+      free(document_format);
+
       if (cupsLastError() > IPP_STATUS_OK_EVENTS_COMPLETE) {
 	debug_printf("ERROR: Unable to set \"" CUPS_BROWSED_DEST_PRINTER
 		     "-default\" option to communicate the destination server for this job (%s)!\n",

--- a/utils/cups-browsed.c
+++ b/utils/cups-browsed.c
@@ -1408,8 +1408,8 @@ void add_mimetype_attributes(char* cluster_name, ipp_t **merged_attributes)
       for (q = (char *)cupsArrayFirst(list),i=0;
 	   q;
 	   q = (char *)cupsArrayNext(list),i++) {
-        values[i]=malloc(sizeof(char)*strlen(q)+1);
-        strncpy(values[i], q, sizeof(values[i]) - 1);
+        values[i]=malloc(sizeof(char) * (strlen(q) + 1));
+        snprintf(values[i], strlen(q) + 1, "%s", q);
       }
       ippAddStrings(*merged_attributes, IPP_TAG_PRINTER,IPP_TAG_MIMETYPE,
 		    attributes[attr_no], num_value, NULL,
@@ -1480,8 +1480,8 @@ void add_tagzero_attributes(char* cluster_name, ipp_t **merged_attributes)
       /* Transferring attributes value from cups Array to char* array*/
       for (q = (char *)cupsArrayFirst(list), i = 0; q;
            q = (char *)cupsArrayNext(list), i ++) {
-        values[i] = malloc(sizeof(char) * strlen(q) + 1);
-        strncpy(values[i], q, sizeof(values[i]) - 1);
+        values[i] = malloc(sizeof(char) * (strlen(q) + 1));
+        snprintf(values[i], strlen(q) + 1, "%s", q);
       }
       ippAddStrings(*merged_attributes, IPP_TAG_PRINTER,
                     IPP_TAG_KEYWORD, attributes[attr_no],
@@ -1551,8 +1551,8 @@ void add_keyword_attributes(char* cluster_name, ipp_t **merged_attributes)
       for (q = (char *)cupsArrayFirst(list), i=0;
 	   q;
 	   q = (char *)cupsArrayNext(list), i ++) {
-        values[i] = malloc(sizeof(char) * strlen(q) + 1);
-        strncpy(values[i], q, sizeof(values[i]) - 1);
+        values[i] = malloc(sizeof(char) * (strlen(q) + 1));
+        snprintf(values[i], strlen(q) + 1, "%s", q);
       }
       ippAddStrings(*merged_attributes, IPP_TAG_PRINTER, IPP_TAG_KEYWORD,
 		    attributes[attr_no], num_value, NULL,

--- a/utils/cups-browsed.c
+++ b/utils/cups-browsed.c
@@ -1484,8 +1484,8 @@ void add_tagzero_attributes(char* cluster_name, ipp_t **merged_attributes)
         strncpy(values[i], q, sizeof(values[i]) - 1);
       }
       ippAddStrings(*merged_attributes, IPP_TAG_PRINTER,
-		    IPP_CONST_TAG(IPP_TAG_KEYWORD),
-                    attributes[attr_no], num_value, NULL,
+                    IPP_TAG_KEYWORD, attributes[attr_no],
+                    num_value, NULL,
                     (const char * const *)values);
 
       for (int k = 0; k < i; k++) {

--- a/utils/cups-browsed.c
+++ b/utils/cups-browsed.c
@@ -8771,6 +8771,21 @@ gboolean update_cups_queues(gpointer unused) {
 	p->timeout = current_time + pause_between_cups_queue_updates;
 
  cannot_create:
+  if (printer_attributes != NULL && num_cluster_printers != 1)
+    ippDelete(printer_attributes);
+
+  if (default_pagesize != NULL && num_cluster_printers != 1)
+    free(default_pagesize);
+
+  if (conflicts != NULL && num_cluster_printers != 1)
+    cupsArrayDelete(conflicts);
+
+  if (make_model != NULL && num_cluster_printers != 1)
+    free(make_model);
+
+  if (sizes != NULL && num_cluster_printers != 1)
+    cupsArrayDelete(sizes);
+
   if (p && !in_shutdown)
     remove_printer_entry(p);
 

--- a/utils/cups-browsed.c
+++ b/utils/cups-browsed.c
@@ -6535,12 +6535,14 @@ on_job_state (CupsNotifier *object,
 	      min_res->x = res->x;
 	      min_res->y = res->y;
 	    } else {
-	      if(compare_resolutions((void *)res,(void *)max_res,NULL) > 0)
+	      if(compare_resolutions((void *)res,(void *)max_res,NULL) > 0) {
 		max_res->x = res->x;
 		max_res->y = res->y;
-	      if(compare_resolutions((void *)res,(void *)min_res,NULL) < 0)
+	      }
+	      if(compare_resolutions((void *)res,(void *)min_res,NULL) < 0) {
 		min_res->x = res->x;
 		min_res->y = res->y;
+	      }
 	    }
 	    free_resolution(res, NULL);
 	    res = NULL;

--- a/utils/cups-browsed.c
+++ b/utils/cups-browsed.c
@@ -3230,15 +3230,15 @@ int supports_job_attributes_requested(const gchar* printer, int printer_index,
   ipp_attribute_t       *attr, *attr1;
   ipp_t                 *request, *response = NULL;
   const char            *str, *side, *resource;
-  cups_array_t          *job_sheet_supported,
-                        *multiple_doc_supported, *print_qualities,
-                        *media_type_supported, *staplelocation_supported,
-                        *foldtype_supported, *punchmedia_supported,
-                        *color_supported;
+  cups_array_t          *job_sheet_supported = NULL,
+                        *multiple_doc_supported = NULL, *print_qualities = NULL,
+                        *media_type_supported = NULL, *staplelocation_supported = NULL,
+                        *foldtype_supported = NULL, *punchmedia_supported = NULL,
+                        *color_supported = NULL;
   remote_printer_t      *p;
   int                   i, count, side_found, orien_req, orien,
                         orien_found;
-  cups_array_t          *sizes;
+  cups_array_t          *sizes = NULL;
   int                   ret = 1;
 
   p = (remote_printer_t *)cupsArrayIndex(remote_printers, printer_index);
@@ -3508,7 +3508,26 @@ int supports_job_attributes_requested(const gchar* printer, int printer_index,
   }
 
   cleanup:
-    ippDelete(response);
+    if (response != NULL)
+      ippDelete(response);
+    if (job_sheet_supported != NULL)
+      cupsArrayDelete(job_sheet_supported);
+    if (multiple_doc_supported)
+      cupsArrayDelete(multiple_doc_supported);
+    if (media_type_supported != NULL)
+      cupsArrayDelete(media_type_supported);
+    if (staplelocation_supported != NULL)
+      cupsArrayDelete(staplelocation_supported);
+    if (foldtype_supported != NULL)
+      cupsArrayDelete(foldtype_supported);
+    if (punchmedia_supported != NULL)
+      cupsArrayDelete(punchmedia_supported);
+    if (color_supported != NULL)
+      cupsArrayDelete(color_supported);
+    if (print_qualities != NULL)
+      cupsArrayDelete(print_qualities);
+    if (sizes != NULL)
+      cupsArrayDelete(sizes);
 
   return ret;
 }

--- a/utils/cups-browsed.c
+++ b/utils/cups-browsed.c
@@ -3082,6 +3082,7 @@ void get_cluster_default_attributes(ipp_t** merged_attributes,
     free(temp->media_source);
     free(temp->media_type);
     free(temp);
+    ippDelete(current_media);
   }
 
   /*Finding the default colormodel for the cluster*/

--- a/utils/cups-browsed.c
+++ b/utils/cups-browsed.c
@@ -2672,7 +2672,6 @@ cups_array_t* get_cluster_sizes(char* cluster_name)
   cups_array_t         *cluster_sizes = NULL,
                        *sizes_ppdname;
   cups_size_t          *size;
-  pagesize_count_t     *temp;
   remote_printer_t     *p;
   ipp_attribute_t      *defattr;
   char                 ppdname[41], pagesize[128];
@@ -2680,7 +2679,6 @@ cups_array_t* get_cluster_sizes(char* cluster_name)
   int                  min_length, min_width, max_length, max_width,
                        bottom, left, right, top;
 
-  temp = (pagesize_count_t *)malloc(sizeof(pagesize_count_t));
   cluster_sizes = cupsArrayNew3((cups_array_func_t)pwg_compare_sizes,
 				NULL, NULL, 0,
 				(cups_acopy_func_t)pwg_copy_size,
@@ -2706,8 +2704,6 @@ cups_array_t* get_cluster_sizes(char* cluster_name)
       sizes = generate_sizes(p->prattrs, &defattr, &min_length, &min_width,
 			     &max_length, &max_width,
 			     &bottom, &left, &right, &top, ppdname);
-      temp->pagesize = ppdname;
-      temp->count = 1;
       for (size = (cups_size_t *)cupsArrayFirst(sizes);
 	   size; size = (cups_size_t *)cupsArrayNext(sizes)) {
 	if (!cupsArrayFind(cluster_sizes, size)) {

--- a/utils/cups-browsed.c
+++ b/utils/cups-browsed.c
@@ -1763,7 +1763,7 @@ void add_mediasize_attributes(char* cluster_name, ipp_t **merged_attributes)
   ipp_t                *media_size;
   cups_array_t         *sizes, *size_ranges;
   media_size_t         *temp, *media_s;
-  pagesize_range_t     *temp_range;
+  pagesize_range_t     *temp_range = NULL, *range = NULL;
   char* attributes[] = {
                          "media-size-supported",
                        };
@@ -1836,12 +1836,12 @@ void add_mediasize_attributes(char* cluster_name, ipp_t **merged_attributes)
       }
     }
     if (num_ranges) {
-      for (temp_range = cupsArrayFirst(size_ranges); temp_range;
-	   i++, temp_range = cupsArrayNext(size_ranges)) {
-        ipp_t *size_range = create_media_range(temp_range->x_dim_min,
-					       temp_range->x_dim_max,
-					       temp_range->y_dim_min,
-					       temp_range->y_dim_max);
+      for (range = cupsArrayFirst(size_ranges); range;
+	   i++, range = cupsArrayNext(size_ranges)) {
+        ipp_t *size_range = create_media_range(range->x_dim_min,
+					       range->x_dim_max,
+					       range->y_dim_min,
+					       range->y_dim_max);
         ippSetCollection(*merged_attributes, &media_size_supported, i,
 			 size_range);
         ippDelete(size_range);

--- a/utils/cups-browsed.c
+++ b/utils/cups-browsed.c
@@ -6167,7 +6167,7 @@ on_job_state (CupsNotifier *object,
   cups_option_t *options;
   int num_of_printers;
   char* document_format;
-  int  print_quality;
+  int  print_quality = 0;
   const char *pdl = NULL;
   cups_array_t *pdl_list;
   char         resolution[32];

--- a/utils/cups-browsed.c
+++ b/utils/cups-browsed.c
@@ -3615,7 +3615,7 @@ new_local_printer (const char *device_uri,
 {
   local_printer_t *printer = g_malloc (sizeof (local_printer_t));
   printer->device_uri = strdup (device_uri);
-  printer->uuid = (uuid ? strdup (uuid) : NULL);
+  printer->uuid = (char*)uuid;
   printer->cups_browsed_controlled = cups_browsed_controlled;
   return printer;
 }
@@ -3797,7 +3797,7 @@ get_printer_uuid(http_t *http_printer,
 
 
   if (attr)
-    uuid = ippGetString(attr, 0, NULL) + 9;
+    uuid = strdup(ippGetString(attr, 0, NULL) + 9);
   else {
     debug_printf ("Printer with URI %s: Cannot read \"printer-uuid\" IPP attribute!\n",
 		  raw_uri);


### PR DESCRIPTION
I ran cups-browsed in several scenarios within valgrind:

1) discovering a print queue from cupsd via legacy CUPS protocol
2) discovering a printer via Avahi
3) discovering a print queue via Avahi and via legacy CUPS protocol at the same time -> cups-browsed creates a cluster
4) printing via print queue which was discovered via legacy CUPS protocol
5) printing via print queue discovered by Avahi
6) printing via cluster

and found several issues. They are fixed via changes below, each commit contains a description what was the problem and how it is fixed, if it is not obvious. Especially, please let me know of your opinion about fixing leaks within tag zero attributes.

I tested it manually (checking valgrind results and if printing went ok) and via our internal CI, and the tests passed.

Would you mind adding the changes into the project?

Thank you in advance,

Zdenek