### PR TITLE
pdftopdf : Fix no final_content_type environment variable found bug

### DIFF
--- a/filter/pdftopdf.c
+++ b/filter/pdftopdf.c
@@ -52,9 +52,8 @@ main(int  argc,				/* I - Number of command-line args */
 #else
   signal(SIGTERM, cancel_job);
 #endif /* HAVE_SIGSET */
-  filter_out_format_t outformat = OUTPUT_FORMAT_PDF;
-  ret = filterCUPSWrapper(argc, argv, pdftopdf, &outformat, &JobCanceled);
-
+  char *t = getenv("FINAL_CONTENT_TYPE");
+  ret = filterCUPSWrapper(argc, argv, pdftopdf, t, &JobCanceled);
   if (ret)
     fprintf(stderr, "ERROR: pdftopdf filter function failed.\n");
 

--- a/filter/pdftopdf.c
+++ b/filter/pdftopdf.c
@@ -52,8 +52,8 @@ main(int  argc,				/* I - Number of command-line args */
 #else
   signal(SIGTERM, cancel_job);
 #endif /* HAVE_SIGSET */
-
-  ret = filterCUPSWrapper(argc, argv, pdftopdf, NULL, &JobCanceled);
+  filter_out_format_t outformat = OUTPUT_FORMAT_PDF;
+  ret = filterCUPSWrapper(argc, argv, pdftopdf, &outformat, &JobCanceled);
 
   if (ret)
     fprintf(stderr, "ERROR: pdftopdf filter function failed.\n");


### PR DESCRIPTION
Upon running pdftopdf filter, 
`DEBUG: pdftopdf: No FINAL_CONTENT_TYPE environment variable, could not determine whether to log pages or not, so turned off page logging.`

This Debug statement was being printed. This was because in pdftopdf.c , NULL was being sent to the parameters argument instead of the final output type. 
So the fix is to send `OUTPUT_FORMAT_PDF` in the argument, instead of NULL.