### PR TITLE
cups-browsed.service: Adapt to changes in CUPS

### DIFF
--- a/utils/cups-browsed.service
+++ b/utils/cups-browsed.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Make remote CUPS printers available locally
-Requires=cups.service
-After=cups.service avahi-daemon.service
+Requires=org.cups.cupsd.service
+After=org.cups.cupsd.service avahi-daemon.service
 Wants=avahi-daemon.service
 
 [Service]


### PR DESCRIPTION
Upstream CUPS seems to install org.cups.cupsd.service now instead of cups.service.