### PR TITLE
implicitclass: 20s policy

### DIFF
--- a/backend/implicitclass.c
+++ b/backend/implicitclass.c
@@ -156,8 +156,8 @@ main(int  argc,				/* I - Number of command-line args */
     httpAssembleURIf(HTTP_URI_CODING_ALL, uri, sizeof(uri), "ipp", NULL,
 		     "localhost", ippPort(), "/printers/%s", queue_name);
     job_id = argv[1];
-    for (i = 0; i < 40; i++) {
-      /* Wait up to 20 sec for cups-browsed to supply the destination host */
+    for (i = 0; i < 120; i++) {
+      /* Wait up to 60 sec for cups-browsed to supply the destination host */
       /* Try reading the option in which cups-browsed has deposited the
 	 destination host */
       request = ippNewRequest(IPP_OP_GET_PRINTER_ATTRIBUTES);
@@ -220,7 +220,7 @@ main(int  argc,				/* I - Number of command-line args */
       usleep(500000);
     }
 
-    if (i >= 40) {
+    if (i >= 120) {
       /* Timeout, no useful data from cups-browsed received */
       fprintf(stderr, "ERROR: No destination host name supplied by cups-browsed for printer \"%s\", is cups-browsed running?\n",
 	      queue_name);


### PR DESCRIPTION
For the convenience in communication with the printer, when the network is too busy that cups-browsed is not able to respond within the time limit, couldn't we increase the usleep() time or no. of loops in implicitclass to make it from 20 sec to 60 sec in order to work in all conditions and modes.