### PR TITLE
cups-browsed: Save default options

### DIFF
--- a/utils/cups-browsed.c
+++ b/utils/cups-browsed.c
@@ -5643,7 +5643,7 @@ record_printer_options(const char *printer) {
 	if (*ptr != NULL) {
 	  if (strcasecmp(key, CUPS_BROWSED_DEST_PRINTER "-default") != 0 &&
 	      (ppdname == NULL ||
-	       strncasecmp(key + strlen(key) - 8, "-default", 8))) {
+	       strncasecmp(key + strlen(key) - 8, "-default", 8) == 0)) {
 	    ippAttributeString(attr, buf, sizeof(buf));
 	    buf[sizeof(buf) - 1] = '\0';
 	    c = buf;


### PR DESCRIPTION
cups-browsed doesn't currently save printer options with the suffix "-default".  For example running:

`lpadmin -p my-queue -o lpi-default=18`

will change the defaults, but then the default doesn't persist when cups-browsed is restarted. 