### PR TITLE
utils/cups-browsed.service: Add network-online.target

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -286,6 +286,7 @@ CHANGES IN V2.0.0
 	- Sample PPDs: In Generic-PDF_Printer-PDF.ppd add option to
 	  switch between color and grayscale printing (Pull request
 	  #237).
+	- cups-browsed.service: Start after network-online.target
 
 CHANGES IN V1.27.5
 

--- a/utils/cups-browsed.service
+++ b/utils/cups-browsed.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Make remote CUPS printers available locally
 Requires=cups.service
-After=cups.service avahi-daemon.service
-Wants=avahi-daemon.service
+After=cups.service avahi-daemon.service network-online.target
+Wants=avahi-daemon.service network-online.target
 
 [Service]
 ExecStart=/usr/sbin/cups-browsed


### PR DESCRIPTION
cups-browsed can be set to browsepolling remote servers, browsing remote
queues via CUPS protocol or sharing local queues via CUPS protocol.
Although sharing and browsing happens via browsesocket (which can be
solved by setting socket option IP_FREEBIND), browsepolling must have
network working to communicate with a remote server.

Would you mind adding the PR to the project?