### PR TITLE
remove support for asymmetric ppi in imagesto___ filters and use ppi=…

### DIFF
--- a/cupsfilters/imagetopdf.c
+++ b/cupsfilters/imagetopdf.c
@@ -983,8 +983,8 @@ imagetopdf(int inputfd,         /* I - File descriptor input stream */
 
   if ((val = cupsGetOption("ppi", num_options, options)) != NULL)
   {
-    if (sscanf(val, "%dx%d", &xppi, &yppi) < 2)
-      yppi = xppi;
+    sscanf(val, "%d", &xppi);
+    yppi = xppi;
     zoom = 0.0;
   }
 

--- a/cupsfilters/imagetops.c
+++ b/cupsfilters/imagetops.c
@@ -350,8 +350,8 @@ imagetops(int inputfd,         /* I - File descriptor input stream */
 
   if ((val = cupsGetOption("ppi", num_options, options)) != NULL)
   {
-    if (sscanf(val, "%dx%d", &xppi, &yppi) < 2)
-      yppi = xppi;
+    sscanf(val, "%d", &xppi);
+    yppi = xppi;
     zoom = 0.0;
   }
 

--- a/cupsfilters/imagetoraster.c
+++ b/cupsfilters/imagetoraster.c
@@ -419,8 +419,8 @@ imagetoraster(int inputfd,         /* I - File descriptor input stream */
 
   if ((val = cupsGetOption("ppi", num_options, options)) != NULL)
   {
-    if (sscanf(val, "%dx%d", &xppi, &yppi) < 2)
-      yppi = xppi;
+    sscanf(val, "%d", &xppi);
+    yppi = xppi;
     zoom = 0.0;
   }
 


### PR DESCRIPTION
…XXX as integer as it is in cups

Solves #347 