### PR TITLE
Pdftoraster: free colour data after processing of each page

### DIFF
--- a/filter/pdftoraster.cxx
+++ b/filter/pdftoraster.cxx
@@ -1231,8 +1231,8 @@ static void writePageImage(cups_raster_t *raster, poppler::document *doc,
         bp += rowsize;
       }
     }
-    free(colordata);
   }
+  free(colordata);
   if (allocLineBuf) delete[] lineBuf;
 }
 

--- a/filter/pdftoraster.cxx
+++ b/filter/pdftoraster.cxx
@@ -1231,6 +1231,7 @@ static void writePageImage(cups_raster_t *raster, poppler::document *doc,
         bp += rowsize;
       }
     }
+    free(colordata);
   }
   if (allocLineBuf) delete[] lineBuf;
 }


### PR DESCRIPTION
This PR is related to the bug :- https://bugs.launchpad.net/ubuntu/+source/cups-filters/+bug/1920190 
RAM(4 GB) improves from 32% usage to 7% for pdftoraster filter.