### PR TITLE
driverless.c: Return 0 if ippfind finds nothing

### DIFF
--- a/utils/driverless.c
+++ b/utils/driverless.c
@@ -573,6 +573,10 @@ list_printers (int mode, int reg_type_no, int isFax)
   if (WIFEXITED(wait_status)) {
     /* Via exit() anywhere or return() in the main() function */
     exit_status = WEXITSTATUS(wait_status);
+    /* if we get 1 from ippfind, it is actually a correct value, not an error,
+     * because CUPS backends return 0 if they don't find any queues */
+    if (exit_status == 1)
+      exit_status = 0;
     if (exit_status)
       fprintf(stderr, "ERROR: ippfind (PID %d) stopped with status %d!\n",
 	      ippfind_pid, exit_status);


### PR DESCRIPTION
Fixes #375, CUPS backends return 0 if they don't find a queue,
driverless should follow the convention.