### PR TITLE
ghostscript filters(gstopxl, gstoraster, gstopdf) now PPD file independent.

### DIFF
--- a/cupsfilters/imagetopdf.c
+++ b/cupsfilters/imagetopdf.c
@@ -866,7 +866,7 @@ imagetopdf(int inputfd,         /* I - File descriptor input stream */
   /* The filterSetCommonOptions() does not set doc.Color
      according to option settings (user's demand for color/gray),
      so we parse the options and set the mode here */
-  cupsRasterParseIPPOptions(&h, num_options, options, 0, 1);
+  cupsRasterParseIPPOptions(&h, data, 0, 1);
   if (doc.Color)
     doc.Color = h.cupsNumColors <= 1 ? 0 : 1;
   if (!doc.ppd) {

--- a/cupsfilters/imagetops.c
+++ b/cupsfilters/imagetops.c
@@ -277,7 +277,7 @@ imagetops(int inputfd,         /* I - File descriptor input stream */
   /* The filterSetCommonOptions() does not set doc.Color
      according to option settings (user's demand for color/gray),
      so we parse the options and set the mode here */
-  cupsRasterParseIPPOptions(&h, num_options, options, 0, 1);
+  cupsRasterParseIPPOptions(&h, data, 0, 1);
   if (doc.Color)
     doc.Color = h.cupsNumColors <= 1 ? 0 : 1;
   if (!ppd) {

--- a/cupsfilters/pclmtoraster.cxx
+++ b/cupsfilters/pclmtoraster.cxx
@@ -194,7 +194,7 @@ parseOpts(filter_data_t *data,
          !strcasecmp(attr->value, "yes")))
       pclmtoraster_data->pwgraster = 1;
     if (pclmtoraster_data->pwgraster == 1)
-      cupsRasterParseIPPOptions(header, num_options, options,
+      cupsRasterParseIPPOptions(header, data,
 				pclmtoraster_data->pwgraster, 0);
 #endif /* HAVE_CUPS_1_7 */
   } else {
@@ -210,7 +210,7 @@ parseOpts(filter_data_t *data,
       else
         pclmtoraster_data->pwgraster = 0;
     }
-    cupsRasterParseIPPOptions(header, num_options, options,
+    cupsRasterParseIPPOptions(header, data,
 			      pclmtoraster_data->pwgraster, 1);
 #else
     if (log) log(ld, FILTER_LOGLEVEL_ERROR,

--- a/cupsfilters/pdftoraster.cxx
+++ b/cupsfilters/pdftoraster.cxx
@@ -411,7 +411,7 @@ static void parseOpts(filter_data_t *data, pdftoraster_doc_t *doc)
 	 !strcasecmp(attr->value, "yes")))
       doc->pwgraster = 1;
     if (doc->pwgraster == 1)
-      cupsRasterParseIPPOptions(&(doc->header), num_options, options, doc->pwgraster, 0);
+      cupsRasterParseIPPOptions(&(doc->header), data, doc->pwgraster, 0);
 #endif /* HAVE_CUPS_1_7 */
   } else {
 #ifdef HAVE_CUPS_1_7
@@ -426,7 +426,7 @@ static void parseOpts(filter_data_t *data, pdftoraster_doc_t *doc)
       else
 	doc->pwgraster = 0;
     }
-    cupsRasterParseIPPOptions(&(doc->header),num_options,options,doc->pwgraster,1);
+    cupsRasterParseIPPOptions(&(doc->header),data,doc->pwgraster,1);
 #else
       if (log) log(ld, FILTER_LOGLEVEL_ERROR,
         "pdftoraster: No PPD file specified.");

--- a/cupsfilters/raster.h
+++ b/cupsfilters/raster.h
@@ -49,10 +49,12 @@ extern int              cupsRasterSetColorSpace(cups_page_header2_t *h,
 						cups_cspace_t *cspace,
 						int *high_depth);
 extern int              cupsRasterParseIPPOptions(cups_page_header2_t *h,
-						  int num_options,
-						  cups_option_t *options,
+						  filter_data_t *data,
 						  int pwg_raster,
 						  int set_defaults);
+extern int				joinJobOptionsAndAttrs(filter_data_t *data, 
+						int num_options, 
+						cups_option_t **options);
 
 #  ifdef __cplusplus
 }

--- a/filter/mupdftoraster.c
+++ b/filter/mupdftoraster.c
@@ -251,6 +251,7 @@ main (int argc, char **argv, char *envp[])
   ppd_file_t *ppd = NULL;
   struct sigaction sa;
   cm_calibration_t cm_calibrate;
+  filter_data_t data;
 #ifdef HAVE_CUPS_1_7
   ppd_attr_t *attr;
 #endif /* HAVE_CUPS_1_7 */
@@ -316,6 +317,26 @@ main (int argc, char **argv, char *envp[])
     }
     strncpy(infilename, argv[6], sizeof(infilename) - 1);
   }
+  if ((data.printer = getenv("PRINTER")) == NULL)
+    data.printer = argv[0];
+  data.job_id = atoi(argv[1]);
+  data.job_user = argv[2];
+  data.job_title = argv[3];
+  data.copies = atoi(argv[4]);
+  data.job_attrs = NULL;        /* We use command line options */
+  data.printer_attrs = NULL;    /* We use the queue's PPD file */
+  data.num_options = num_options;
+  data.options = options;       /* Command line options from 5th arg */
+  data.ppdfile = getenv("PPD"); /* PPD file name in the "PPD"
+					  environment variable. */
+  data.ppd = ppd;
+                                       /* Load PPD file */
+  data.logfunc = cups_logfunc;  /* Logging scheme of CUPS */
+  data.logdata = NULL;
+  data.iscanceledfunc = cups_iscanceledfunc; /* Job-is-canceled
+						       function */
+  data.iscanceleddata = NULL;
+
 
   /* If doc type is not PDF exit */
   if(parse_doc_type(fp))
@@ -362,11 +383,11 @@ main (int argc, char **argv, char *envp[])
     h.cupsWidth = h.HWResolution[0] * h.PageSize[0] / 72;
     h.cupsHeight = h.HWResolution[1] * h.PageSize[1] / 72;
 #ifdef HAVE_CUPS_1_7
-    cupsRasterParseIPPOptions(&h, num_options, options, 1, 0);
+    cupsRasterParseIPPOptions(&h, &data, 1, 0);
 #endif /* HAVE_CUPS_1_7 */
   } else {
 #ifdef HAVE_CUPS_1_7
-    cupsRasterParseIPPOptions(&h, num_options, options, 1, 1);
+    cupsRasterParseIPPOptions(&h, &data, 1, 1);
 #else
     fprintf(stderr, "ERROR: No PPD file specified.\n");
     goto out;


### PR DESCRIPTION
1. Ghostscript (gstopxl, gstoraster, gstopdf) now PPD file independent.
2. Updated cupsRasterParseIPPOptions to support Job-attrs.
3. Made cupsRasterPrepareHeader PPD file independent.

I will soon write an alternative function ppdRasterInterpretPPD which uses printer-attrs instead of PPD file and will make its use wherever needed.
Thanks