### PR TITLE
pdftopdf: Fix page ranges like "10-2147483647"

### DIFF
--- a/cupsfilters/pdftopdf/pdftopdf.cc
+++ b/cupsfilters/pdftopdf/pdftopdf.cc
@@ -256,7 +256,7 @@ static void parseRanges(const char *range,IntervalSet &ret) // {{{
         } else {
           upper=strtol(range,(char **)&range,10);
           if (upper>=2147483647) {
-            ret.add(1);
+            ret.add(lower);
           } else {
             ret.add(lower,upper+1);
           }


### PR DESCRIPTION
Trying to print a page range using a command like "`lp -P 10- /etc/services`" doesn't work because pdftopdf doesn't properly recognize the print option that results from the command (`page-ranges=10-2147483647`).  Pdftopdf translates `page-ranges=10-2147483647)` to `[1,inf)` instead of `[10,inf)`.