### PR TITLE
Missing closing file in some functions 

### DIFF
--- a/cupsfilters/ghostscript.c
+++ b/cupsfilters/ghostscript.c
@@ -927,6 +927,7 @@ ghostscript(int inputfd,         /* I - File descriptor input stream */
       {
 	if (log) log(ld, FILTER_LOGLEVEL_ERROR,
 		     "ghostscript: Unable to copy PDF file: %s", strerror(errno));
+	fclose(fp);
 	return (1);
       }
 

--- a/cupsfilters/imagetopdf.c
+++ b/cupsfilters/imagetopdf.c
@@ -794,6 +794,7 @@ imagetopdf(int inputfd,         /* I - File descriptor input stream */
       if (log) log(ld, FILTER_LOGLEVEL_ERROR,
 		   "imagetopdf: Unable to copy input: %s",
 		   strerror(errno));
+      fclose(fp);
       return (1);
     }
 

--- a/cupsfilters/imagetoraster.c
+++ b/cupsfilters/imagetoraster.c
@@ -335,6 +335,7 @@ imagetoraster(int inputfd,         /* I - File descriptor input stream */
       if (log) log(ld, FILTER_LOGLEVEL_ERROR,
 		   "imagetoraster: Unable to copy input: %s",
 		   strerror(errno));
+      fclose(fp);
       return (1);
     }
 


### PR DESCRIPTION
In some files, the input data stream is opened but not closed after the filter function returns, if it is unable to copy the input data to a tempfile.
See issue #437.
So issue is now solved by shutting the data stream when the filter function returns with an error