### PR TITLE
Added option input-page-ranges in pdftopdf filter

### DIFF
--- a/cupsfilters/pdftopdf/pdftopdf.cc
+++ b/cupsfilters/pdftopdf/pdftopdf.cc
@@ -589,8 +589,8 @@ void getParameters(filter_data_t *data,int num_options,cups_option_t *options,Pr
     parseRanges(val,param.pageRange);
   }
 
-  if ((val=cupsGetOption("orig-page-ranges",num_options,options)) !=NULL){
-    parseRanges(val,param.origPageRange);
+  if ((val=cupsGetOption("input-page-ranges",num_options,options)) !=NULL){
+    parseRanges(val,param.inputPageRange);
   }
 
   ppd_choice_t *choice;

--- a/cupsfilters/pdftopdf/pdftopdf.cc
+++ b/cupsfilters/pdftopdf/pdftopdf.cc
@@ -589,6 +589,10 @@ void getParameters(filter_data_t *data,int num_options,cups_option_t *options,Pr
     parseRanges(val,param.pageRange);
   }
 
+  if ((val=cupsGetOption("orig-page-ranges",num_options,options)) !=NULL){
+    parseRanges(val,param.origPageRange);
+  }
+
   ppd_choice_t *choice;
   if ((choice=ppdFindMarkedChoice(ppd,"MirrorPrint")) != NULL) {
     val=choice->choice;

--- a/cupsfilters/pdftopdf/pdftopdf_processor.cc
+++ b/cupsfilters/pdftopdf/pdftopdf_processor.cc
@@ -32,14 +32,7 @@ bool ProcessingParameters::withPage(int outno) const // {{{
 // }}}
 bool ProcessingParameters::havePage(int pageno) const
 {
-  if (pageno%2 == 0) { // 1-based
-    if (!evenPages) {
-      return false;
-    }
-  } else if (!oddPages) {
-    return false;
-  }
-  return origPageRange.contains(pageno);
+  return inputPageRange.contains(pageno);
 }
 
 void ProcessingParameters::dump(pdftopdf_doc_t *doc) const // {{{
@@ -80,8 +73,8 @@ void ProcessingParameters::dump(pdftopdf_doc_t *doc) const // {{{
 				 (oddPages)?"true":"false");
   
    if (doc->logfunc) doc->logfunc(doc->logdata, FILTER_LOGLEVEL_DEBUG,
-				 "pdftopdf: orig page range:");
-  origPageRange.dump(doc);
+				 "pdftopdf: input page range:");
+  inputPageRange.dump(doc);
 
   if (doc->logfunc) doc->logfunc(doc->logdata, FILTER_LOGLEVEL_DEBUG,
 				 "pdftopdf: page range:");
@@ -190,13 +183,13 @@ bool processPDFTOPDF(PDFTOPDF_Processor &proc,ProcessingParameters &param,pdftop
 
   std::vector<std::shared_ptr<PDFTOPDF_PageHandle>> pages=proc.get_pages(doc);
   
-  std::vector<int> orig_page_range_list;
+  std::vector<std::shared_ptr<PDFTOPDF_PageHandle>> input_page_range_list;
    
    for(int i=1;i<=(int)pages.size();i++)
       if(param.havePage(i))
-      orig_page_range_list.push_back(i-1);
+      input_page_range_list.push_back(pages[i-1]);
 
-  const int numOrigPages=orig_page_range_list.size(); 
+  const int numOrigPages=input_page_range_list.size(); 
 
   // TODO FIXME? elsewhere
   std::vector<int> shuffle;
@@ -212,7 +205,7 @@ bool processPDFTOPDF(PDFTOPDF_Processor &proc,ProcessingParameters &param,pdftop
     shuffle.resize(numOrigPages);
     std::iota(shuffle.begin(),shuffle.end(),0);
   }
-  const int numPages=std::max(shuffle.size(),orig_page_range_list.size());
+  const int numPages=std::max(shuffle.size(),input_page_range_list.size());
 
   if (doc->logfunc) doc->logfunc(doc->logdata, FILTER_LOGLEVEL_DEBUG,
 				 "pdftopdf: \"print-scaling\" IPP attribute: %s",
@@ -232,9 +225,9 @@ bool processPDFTOPDF(PDFTOPDF_Processor &proc,ProcessingParameters &param,pdftop
     if ((param.page.width == pw) && (param.page.height == ph))
       margin_defined = false;
 
-    for (int i = 0; i < (int)orig_page_range_list.size(); i ++)
+    for (int i = 0; i < (int)input_page_range_list.size(); i ++)
     {
-      PageRect r = pages[orig_page_range_list[i]]->getRect();
+      PageRect r = input_page_range_list[i]->getRect();
       int w = r.width;
       int h = r.height;
       if ((w > param.page.width || h > param.page.height) &&
@@ -297,9 +290,9 @@ bool processPDFTOPDF(PDFTOPDF_Processor &proc,ProcessingParameters &param,pdftop
 
   if (param.fillprint || param.cropfit)
   {
-    for (int i = 0; i < (int)orig_page_range_list.size(); i ++)
+    for (int i = 0; i < (int)input_page_range_list.size(); i ++)
     {
-      std::shared_ptr<PDFTOPDF_PageHandle> page = pages[orig_page_range_list[i]];
+      std::shared_ptr<PDFTOPDF_PageHandle> page = input_page_range_list[i];
       Rotation orientation = param.orientation;
       if (param.noOrientation &&
 	  page->is_landscape(param.orientation))
@@ -365,7 +358,7 @@ bool processPDFTOPDF(PDFTOPDF_Processor &proc,ProcessingParameters &param,pdftop
       // add empty page as filler
       page = proc.new_page(param.page.width, param.page.height, doc);
     else
-      page = pages[orig_page_range_list[shuffle[iA]]];
+      page = input_page_range_list[shuffle[iA]];
 
     PageRect rect;
     rect = page->getRect();

--- a/cupsfilters/pdftopdf/pdftopdf_processor.cc
+++ b/cupsfilters/pdftopdf/pdftopdf_processor.cc
@@ -30,6 +30,17 @@ bool ProcessingParameters::withPage(int outno) const // {{{
   return pageRange.contains(outno);
 }
 // }}}
+bool ProcessingParameters::havePage(int pageno) const
+{
+  if (pageno%2 == 0) { // 1-based
+    if (!evenPages) {
+      return false;
+    }
+  } else if (!oddPages) {
+    return false;
+  }
+  return origPageRange.contains(pageno);
+}
 
 void ProcessingParameters::dump(pdftopdf_doc_t *doc) const // {{{
 {
@@ -67,6 +78,10 @@ void ProcessingParameters::dump(pdftopdf_doc_t *doc) const // {{{
 				 "pdftopdf: evenPages: %s, oddPages: %s",
 				 (evenPages)?"true":"false",
 				 (oddPages)?"true":"false");
+  
+   if (doc->logfunc) doc->logfunc(doc->logdata, FILTER_LOGLEVEL_DEBUG,
+				 "pdftopdf: orig page range:");
+  origPageRange.dump(doc);
 
   if (doc->logfunc) doc->logfunc(doc->logdata, FILTER_LOGLEVEL_DEBUG,
 				 "pdftopdf: page range:");
@@ -174,7 +189,14 @@ bool processPDFTOPDF(PDFTOPDF_Processor &proc,ProcessingParameters &param,pdftop
   }
 
   std::vector<std::shared_ptr<PDFTOPDF_PageHandle>> pages=proc.get_pages(doc);
-  const int numOrigPages=pages.size();
+  
+  std::vector<int> orig_page_range_list;
+   
+   for(int i=1;i<=(int)pages.size();i++)
+      if(param.havePage(i))
+      orig_page_range_list.push_back(i-1);
+
+  const int numOrigPages=orig_page_range_list.size(); 
 
   // TODO FIXME? elsewhere
   std::vector<int> shuffle;
@@ -190,7 +212,7 @@ bool processPDFTOPDF(PDFTOPDF_Processor &proc,ProcessingParameters &param,pdftop
     shuffle.resize(numOrigPages);
     std::iota(shuffle.begin(),shuffle.end(),0);
   }
-  const int numPages=std::max(shuffle.size(),pages.size());
+  const int numPages=std::max(shuffle.size(),orig_page_range_list.size());
 
   if (doc->logfunc) doc->logfunc(doc->logdata, FILTER_LOGLEVEL_DEBUG,
 				 "pdftopdf: \"print-scaling\" IPP attribute: %s",
@@ -210,9 +232,9 @@ bool processPDFTOPDF(PDFTOPDF_Processor &proc,ProcessingParameters &param,pdftop
     if ((param.page.width == pw) && (param.page.height == ph))
       margin_defined = false;
 
-    for (int i = 0; i < (int)pages.size(); i ++)
+    for (int i = 0; i < (int)orig_page_range_list.size(); i ++)
     {
-      PageRect r = pages[i]->getRect();
+      PageRect r = pages[orig_page_range_list[i]]->getRect();
       int w = r.width;
       int h = r.height;
       if ((w > param.page.width || h > param.page.height) &&
@@ -275,9 +297,9 @@ bool processPDFTOPDF(PDFTOPDF_Processor &proc,ProcessingParameters &param,pdftop
 
   if (param.fillprint || param.cropfit)
   {
-    for (int i = 0; i < (int)pages.size(); i ++)
+    for (int i = 0; i < (int)orig_page_range_list.size(); i ++)
     {
-      std::shared_ptr<PDFTOPDF_PageHandle> page = pages[i];
+      std::shared_ptr<PDFTOPDF_PageHandle> page = pages[orig_page_range_list[i]];
       Rotation orientation = param.orientation;
       if (param.noOrientation &&
 	  page->is_landscape(param.orientation))
@@ -343,7 +365,7 @@ bool processPDFTOPDF(PDFTOPDF_Processor &proc,ProcessingParameters &param,pdftop
       // add empty page as filler
       page = proc.new_page(param.page.width, param.page.height, doc);
     else
-      page = pages[shuffle[iA]];
+      page = pages[orig_page_range_list[shuffle[iA]]];
 
     PageRect rect;
     rect = page->getRect();

--- a/cupsfilters/pdftopdf/pdftopdf_processor.h
+++ b/cupsfilters/pdftopdf/pdftopdf_processor.h
@@ -54,8 +54,8 @@ ProcessingParameters()
     page.right=page.width-18.0;
 
     // everything
-    origPageRange.add(1);
-    origPageRange.finish();
+    inputPageRange.add(1);
+    inputPageRange.finish();
     pageRange.add(1);
     pageRange.finish();
   }
@@ -80,7 +80,7 @@ ProcessingParameters()
   std::string pageLabel;
   bool evenPages,oddPages;
   IntervalSet pageRange;
-  IntervalSet origPageRange;
+  IntervalSet inputPageRange;
 
   bool mirror;
 

--- a/cupsfilters/pdftopdf/pdftopdf_processor.h
+++ b/cupsfilters/pdftopdf/pdftopdf_processor.h
@@ -54,6 +54,8 @@ ProcessingParameters()
     page.right=page.width-18.0;
 
     // everything
+    origPageRange.add(1);
+    origPageRange.finish();
     pageRange.add(1);
     pageRange.finish();
   }
@@ -78,6 +80,7 @@ ProcessingParameters()
   std::string pageLabel;
   bool evenPages,oddPages;
   IntervalSet pageRange;
+  IntervalSet origPageRange;
 
   bool mirror;
 
@@ -104,6 +107,7 @@ ProcessingParameters()
 
   // helper functions
   bool withPage(int outno) const; // 1 based
+  bool havePage(int pageno) const; //1 based
   void dump(pdftopdf_doc_t *doc) const;
 };
 


### PR DESCRIPTION
Added orig-page-range option in pdftopdf filter which will provide more flexibility to the user for printing pages in a certain range. Unlike the existing page-range option, which applies the page-range parameter to the document after it has been processed, the orig-page-ranges option applies page-range before the document has been processed.
This option will also help in the solving the need of user as mentioned in issue #365. 