### PR TITLE
Moves the libppd declarations after cups-filters in Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -161,181 +161,6 @@ pkgcharset_DATA = \
 
 EXTRA_DIST += $(pkgcharset_DATA)
 
-# ==========================
-# PPD legacy support library
-# ==========================
-pkgppdincludedir = $(includedir)/ppd
-pkgppdinclude_DATA = \
-	ppd/ppd.h \
-	ppd/ppdc.h \
-	ppd/ppd-filter.h
-
-pkgppddefsdir = $(datadir)/ppdc
-pkgppddefs_DATA = \
-	ppd/epson.h \
-	ppd/hp.h \
-	ppd/label.h \
-	ppd/font.defs \
-	ppd/media.defs \
-	ppd/raster.defs
-
-lib_LTLIBRARIES = libppd.la
-
-check_PROGRAMS = \
-	testppd
-TESTS = \
-	testppd
-
-libppd_la_SOURCES = \
-	ppd/ppd-attr.c \
-	ppd/ppd.c \
-	ppd/ppd-cache.c \
-	ppd/ppd-collection.cxx \
-	ppd/ppd-conflicts.c \
-	ppd/ppd-custom.c \
-	ppd/ppd-emit.c \
-	ppd/ppd-filter.c \
-	ppd/ppd-generator.c \
-	ppd/ppd-load-profile.c \
-	ppd/ppd-localize.c \
-	ppd/ppd-mark.c \
-	ppd/ppd-page.c \
-	ppd/ppd-ipp.c \
-	ppd/array.c \
-	ppd/array-private.h \
-	ppd/debug.c \
-	ppd/debug-internal.h \
-	ppd/debug-private.h \
-	ppd/encode.c \
-	ppd/file.c \
-	ppd/file-private.h \
-	ppd/imagetops-pstops.c \
-	ppd/ipp-private.h \
-	ppd/language.c \
-	ppd/language-private.h \
-	ppd/pdftops.c \
-	ppd/raster-interpret.c \
-	ppd/raster-error.c \
-	ppd/raster-private.h \
-	ppd/rastertops.c \
-	ppd/string.c \
-	ppd/snprintf.c \
-	ppd/string-private.h \
-	ppd/thread.c \
-	ppd/thread-private.h \
-	ppd/ppdc-array.cxx \
-	ppd/ppdc-attr.cxx \
-	ppd/ppdc-catalog.cxx \
-	ppd/ppdc-choice.cxx \
-	ppd/ppdc-constraint.cxx \
-	ppd/ppdc-driver.cxx \
-	ppd/ppdc-file.cxx \
-	ppd/ppdc-filter.cxx \
-	ppd/ppdc-font.cxx \
-	ppd/ppdc-group.cxx \
-	ppd/ppdc-import.cxx \
-	ppd/ppdc-mediasize.cxx \
-	ppd/ppdc-message.cxx \
-	ppd/ppdc-option.cxx \
-	ppd/ppdc-private.h \
-	ppd/ppdc-profile.cxx \
-	ppd/ppdc-shared.cxx \
-	ppd/ppdc-source.cxx \
-	ppd/ppdc-string.cxx \
-	ppd/ppdc-variable.cxx \
-	$(pkgppdinclude_DATA) \
-	$(pkgppddefs_DATA)
-libppd_la_LIBADD = \
-	libcupsfilters.la \
-	$(CUPS_LIBS)
-libppd_la_CFLAGS = \
-	-I$(srcdir)/cupsfilters/ \
-	$(CUPS_CFLAGS)
-libppd_la_LDFLAGS = \
-	-no-undefined \
-	-version-info 1
-libppd_la_DEPENDENCIES = \
-	libcupsfilters.la
-
-testppd_SOURCES = ppd/testppd.c
-testppd_LDADD = libppd.la \
-		-lcups
-
-EXTRA_DIST += \
-	$(pkgppdinclude_DATA) \
-	$(pkgppddefs_DATA) \
-	ppd/test.ppd \
-	ppd/test2.ppd \
-	ppd/README.md
-
-# ===========================
-# ppdc PPD compiler utilities
-# ===========================
-
-if ENABLE_PPDC_UTILS
-pkgutils_PROGRAMS += \
-	genstrings \
-	ppdc \
-	ppdhtml \
-	ppdi \
-	ppdmerge \
-	ppdpo
-endif
-
-genstrings_SOURCES = \
-	ppd/genstrings.cxx
-genstrings_LDADD = \
-	libppd.la \
-	$(CUPS_LIBS)
-genstrings_CFLAGS = \
-	-I$(srcdir)/ppd/ \
-	$(CUPS_CFLAGS)
-
-ppdc_SOURCES = \
-	ppd/ppdc.cxx
-ppdc_LDADD = \
-	libppd.la \
-	$(CUPS_LIBS)
-ppdc_CFLAGS = \
-	-I$(srcdir)/ppd/ \
-	$(CUPS_CFLAGS)
-
-ppdhtml_SOURCES = \
-	ppd/ppdhtml.cxx
-ppdhtml_LDADD = \
-	libppd.la \
-	$(CUPS_LIBS)
-ppdhtml_CFLAGS = \
-	-I$(srcdir)/ppd/ \
-	$(CUPS_CFLAGS)
-
-ppdi_SOURCES = \
-	ppd/ppdi.cxx
-ppdi_LDADD = \
-	libppd.la \
-	$(CUPS_LIBS)
-ppdi_CFLAGS = \
-	-I$(srcdir)/ppd/ \
-	$(CUPS_CFLAGS)
-
-ppdmerge_SOURCES = \
-	ppd/ppdmerge.cxx
-ppdmerge_LDADD = \
-	libppd.la \
-	$(CUPS_LIBS)
-ppdmerge_CFLAGS = \
-	-I$(srcdir)/ppd/ \
-	$(CUPS_CFLAGS)
-
-ppdpo_SOURCES = \
-	ppd/ppdpo.cxx
-ppdpo_LDADD = \
-	libppd.la \
-	$(CUPS_LIBS)
-ppdpo_CFLAGS = \
-	-I$(srcdir)/ppd/ \
-	$(CUPS_CFLAGS)
-
 # =================
 # Fontembed library
 # =================
@@ -348,13 +173,13 @@ pkgfontembedinclude_DATA = \
 	fontembed/iofn.h \
 	fontembed/sfnt.h
 
-lib_LTLIBRARIES += libfontembed.la
+lib_LTLIBRARIES = libfontembed.la
 
-check_PROGRAMS += \
+check_PROGRAMS = \
 	test-analyze \
 	test-pdf \
 	test-ps
-TESTS += \
+TESTS = \
 	test-analyze \
 	test-pdf \
 	test-ps
@@ -624,6 +449,181 @@ EXTRA_DIST += $(pkgcupsdata_DATA)
 pkgcupsserverrootdir = $(CUPS_SERVERROOT)
 pkgcupsserverroot_DATA = \
 	utils/cups-browsed.conf
+
+# ==========================
+# PPD legacy support library
+# ==========================
+pkgppdincludedir = $(includedir)/ppd
+pkgppdinclude_DATA = \
+	ppd/ppd.h \
+	ppd/ppdc.h \
+	ppd/ppd-filter.h
+
+pkgppddefsdir = $(datadir)/ppdc
+pkgppddefs_DATA = \
+	ppd/epson.h \
+	ppd/hp.h \
+	ppd/label.h \
+	ppd/font.defs \
+	ppd/media.defs \
+	ppd/raster.defs
+
+lib_LTLIBRARIES += libppd.la
+
+check_PROGRAMS += \
+	testppd
+TESTS += \
+	testppd
+
+libppd_la_SOURCES = \
+	ppd/ppd-attr.c \
+	ppd/ppd.c \
+	ppd/ppd-cache.c \
+	ppd/ppd-collection.cxx \
+	ppd/ppd-conflicts.c \
+	ppd/ppd-custom.c \
+	ppd/ppd-emit.c \
+	ppd/ppd-filter.c \
+	ppd/ppd-generator.c \
+	ppd/ppd-load-profile.c \
+	ppd/ppd-localize.c \
+	ppd/ppd-mark.c \
+	ppd/ppd-page.c \
+	ppd/ppd-ipp.c \
+	ppd/array.c \
+	ppd/array-private.h \
+	ppd/debug.c \
+	ppd/debug-internal.h \
+	ppd/debug-private.h \
+	ppd/encode.c \
+	ppd/file.c \
+	ppd/file-private.h \
+	ppd/imagetops-pstops.c \
+	ppd/ipp-private.h \
+	ppd/language.c \
+	ppd/language-private.h \
+	ppd/pdftops.c \
+	ppd/raster-interpret.c \
+	ppd/raster-error.c \
+	ppd/raster-private.h \
+	ppd/rastertops.c \
+	ppd/string.c \
+	ppd/snprintf.c \
+	ppd/string-private.h \
+	ppd/thread.c \
+	ppd/thread-private.h \
+	ppd/ppdc-array.cxx \
+	ppd/ppdc-attr.cxx \
+	ppd/ppdc-catalog.cxx \
+	ppd/ppdc-choice.cxx \
+	ppd/ppdc-constraint.cxx \
+	ppd/ppdc-driver.cxx \
+	ppd/ppdc-file.cxx \
+	ppd/ppdc-filter.cxx \
+	ppd/ppdc-font.cxx \
+	ppd/ppdc-group.cxx \
+	ppd/ppdc-import.cxx \
+	ppd/ppdc-mediasize.cxx \
+	ppd/ppdc-message.cxx \
+	ppd/ppdc-option.cxx \
+	ppd/ppdc-private.h \
+	ppd/ppdc-profile.cxx \
+	ppd/ppdc-shared.cxx \
+	ppd/ppdc-source.cxx \
+	ppd/ppdc-string.cxx \
+	ppd/ppdc-variable.cxx \
+	$(pkgppdinclude_DATA) \
+	$(pkgppddefs_DATA)
+libppd_la_LIBADD = \
+	libcupsfilters.la \
+	$(CUPS_LIBS)
+libppd_la_CFLAGS = \
+	-I$(srcdir)/cupsfilters/ \
+	$(CUPS_CFLAGS)
+libppd_la_LDFLAGS = \
+	-no-undefined \
+	-version-info 1
+libppd_la_DEPENDENCIES = \
+	libcupsfilters.la
+
+testppd_SOURCES = ppd/testppd.c
+testppd_LDADD = libppd.la \
+		-lcups
+
+EXTRA_DIST += \
+	$(pkgppdinclude_DATA) \
+	$(pkgppddefs_DATA) \
+	ppd/test.ppd \
+	ppd/test2.ppd \
+	ppd/README.md
+
+# ===========================
+# ppdc PPD compiler utilities
+# ===========================
+
+if ENABLE_PPDC_UTILS
+pkgutils_PROGRAMS += \
+	genstrings \
+	ppdc \
+	ppdhtml \
+	ppdi \
+	ppdmerge \
+	ppdpo
+endif
+
+genstrings_SOURCES = \
+	ppd/genstrings.cxx
+genstrings_LDADD = \
+	libppd.la \
+	$(CUPS_LIBS)
+genstrings_CFLAGS = \
+	-I$(srcdir)/ppd/ \
+	$(CUPS_CFLAGS)
+
+ppdc_SOURCES = \
+	ppd/ppdc.cxx
+ppdc_LDADD = \
+	libppd.la \
+	$(CUPS_LIBS)
+ppdc_CFLAGS = \
+	-I$(srcdir)/ppd/ \
+	$(CUPS_CFLAGS)
+
+ppdhtml_SOURCES = \
+	ppd/ppdhtml.cxx
+ppdhtml_LDADD = \
+	libppd.la \
+	$(CUPS_LIBS)
+ppdhtml_CFLAGS = \
+	-I$(srcdir)/ppd/ \
+	$(CUPS_CFLAGS)
+
+ppdi_SOURCES = \
+	ppd/ppdi.cxx
+ppdi_LDADD = \
+	libppd.la \
+	$(CUPS_LIBS)
+ppdi_CFLAGS = \
+	-I$(srcdir)/ppd/ \
+	$(CUPS_CFLAGS)
+
+ppdmerge_SOURCES = \
+	ppd/ppdmerge.cxx
+ppdmerge_LDADD = \
+	libppd.la \
+	$(CUPS_LIBS)
+ppdmerge_CFLAGS = \
+	-I$(srcdir)/ppd/ \
+	$(CUPS_CFLAGS)
+
+ppdpo_SOURCES = \
+	ppd/ppdpo.cxx
+ppdpo_LDADD = \
+	libppd.la \
+	$(CUPS_LIBS)
+ppdpo_CFLAGS = \
+	-I$(srcdir)/ppd/ \
+	$(CUPS_CFLAGS)
 
 # =======
 # Drivers


### PR DESCRIPTION
When compiling from source `sudo make install` fails to relink libppd because it depends on libcupsfilters, not yet installed.
Reordering the declarations in the Makefile.am and correcting the assignments of lib_LTLIBRARIES, check_PROGRAMS and TESTS fix the behavior.

To reproduce the issue try on a minimal Ubuntu environment, such as WSL or cloud images running on LXD or docker:

```
sudo apt install autotools-dev autoconf automake autopoint libavahi-client-dev libavahi-glib-dev libcurl4-gnutls-dev libglib2.0-dev libgnutls28-dev libjpeg-dev libpam0g-dev libpng-dev libusb-1.0-0-dev zlib1g-dev libcups2-dev libcupsimage2-dev libssl-dev libtool libqpdf-dev poppler-utils libfontconfig1-dev libpoppler-cpp-dev libtiff5-dev libdbus-1-dev libexif-dev librsvg2-bin sharutils liblcms2-dev ghostscript pkg-config g++ --no-install-recommends

git clone https://github.com/OpenPrinting/cups-filters
cd cups-filters
./autogen.sh
./configure --prefix=/usr --disable-ldap --disable-foomatic --disable-braille --disable-mutool
make
sudo make install
```

Only the install target should fail to relink the libppd against libcupsfilters due the later being not yet installed.