### PR TITLE
Add FrequentNetifUpdate option/directive

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -962,6 +962,19 @@ if test x$enable_debug_guards = xyes; then
         CXXFLAGS="$CXXFLAGS -DDEBUG_GUARDS"
 fi
 
+# =========================================================
+# Turn on/off network interface updates for each found entry
+# ==========================================================
+AC_ARG_ENABLE([frequent_netif_update],
+              [AS_HELP_STRING([--enable-frequent-netif-update], [Enable network interface update after each found entry to prevent network issues])],
+              [FREQUENT_NETIF_UPDATE=$enableval],
+              [FREQUENT_NETIF_UPDATE=yes]
+)
+
+AS_IF([test "x$FREQUENT_NETIF_UPDATE" != "xno"],
+      [AC_DEFINE([FREQUENT_NETIF_UPDATE], [1], [Define whether we want network interface update after each found entry])]
+)
+
 # =====================
 # Prepare all .in files
 # =====================
@@ -1044,6 +1057,7 @@ Build configuration:
 	ppdc utilities:  ${enable_ppdc_utils}
 	local queue naming for remote CUPS queues: ${REMOTE_CUPS_LOCAL_QUEUE_NAMING}
 	keep generated queues during shutdown:     ${SAVING_CREATED_QUEUES}
+	update network interfaces after each found entry:     ${FREQUENT_NETIF_UPDATE}
 	all ipp printer auto-setup: ${enable_auto_setup_all}
 	only driverless auto-setup: ${enable_auto_setup_driverless_only}
 	only local auto-setup: ${enable_auto_setup_local_only}

--- a/utils/cups-browsed.conf.5
+++ b/utils/cups-browsed.conf.5
@@ -977,6 +977,18 @@ and doing specific actions when a D-BUS notification comes.
         NotifLeaseDuration 86400
 .fam T
 .fi
+FrequentNetifUpdate turns on/off the network interface update routines
+which happen for each found entry, which can slow up cups-browsed significantly
+if we are on a network with many shared printers or if we use BrowsePoll to a server
+with many queues. Network interface updates after receiving D-BUS notification
+from NetworkManager won't be turned off with the directive. The default value
+is 'Yes'.
+.PP
+.nf
+.fam C
+        FrequentNetifUpdate Yes
+.fam T
+.fi
 .SH SEE ALSO
 
 \fBcups-browsed\fP(8)

--- a/utils/cups-browsed.conf.in
+++ b/utils/cups-browsed.conf.in
@@ -749,3 +749,12 @@ BrowseRemoteProtocols @BROWSEREMOTEPROTOCOLS@
 # and doing specific actions when a D-BUS notification comes.
 
 # NotifLeaseDuration 86400
+
+# FrequentNetifUpdate turns on/off the network interface update routines
+# which happen for each found entry, which can slow up cups-browsed significantly
+# if we are on a network with many shared printers or if we use BrowsePoll to a server
+# with many queues. Network interface updates after receiving D-BUS notification
+# from NetworkManager won't be turned off with the directive. The default value
+# is 'Yes'.
+#
+# FrequentNetifUpdate Yes


### PR DESCRIPTION
In case clients use BrowsePoll to a server with many queues or there is many printers on the local network, updating network interfaces after every found record slow cups-browsed a lot (f.e. on Fedora this step takes about 2-3s second for every queue). This PR adds FrequentNetifUpdate configure option and directive, which can turn off this update when we examine found records - the network interface update based on NM DBUS notification is not affected with this directive.

Would you mind adding it to the project?

Thank you in advance!