### PR TITLE
use noexcept(false) instead of throw() from c++17 onwards

### DIFF
--- a/filter/pdftoraster.cxx
+++ b/filter/pdftoraster.cxx
@@ -2148,7 +2148,11 @@ int main(int argc, char *argv[]) {
 /* For compatibility with g++ >= 4.7 compilers _GLIBCXX_THROW
  *  should be used as a guard, otherwise use traditional definition */
 #ifndef _GLIBCXX_THROW
+#if __cplusplus < 201703L
 #define _GLIBCXX_THROW throw
+#else
+#define _GLIBCXX_THROW(x) noexcept(false)
+#endif
 #endif
 
 void * operator new(size_t size) _GLIBCXX_THROW (std::bad_alloc)


### PR DESCRIPTION
C++17 removed dynamic exception specifications [1] they had been deprecated since C++11, replace
throw(whatever) with noexcept(false).

[1] https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0003r5.html

Signed-off-by: Khem Raj <raj.khem@gmail.com>