### PR TITLE
Add libexif in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ package. This package retro-fits the filter functions of
 libcupsfilters and libppd to CUPS 2.x.
 
 For compiling and using this package CUPS (2.2.2 or newer),
-libcupsfilters 2.x, and libppd are needed. It is highly recommended,
+libcupsfilters 2.x, libexif, and libppd are needed. It is highly recommended,
 especially if non-PDF printers are used, to have at least one of
 Ghostscript (preferred), Poppler, or MuPDF installed.
 


### PR DESCRIPTION
As mentioned in #480, from cups-filters 1.28.16, `libexif` is now required and is now mentioned in the README.md as well.

In libcupsfilters's INSTALL, it's already mentioned that `libexif` is required to get the image resolution.

I am new to this so please let me know if there's anything.

Thanks in advance!