### PR TITLE
Drop C++ references and obsolete C standards

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -379,11 +379,9 @@ AS_IF([test x"$enable_werror" = "xyes"], [
 ])
 AS_IF([test x"$GCC" = "xyes"], [
 	# Be tough with warnings and produce less careless code
-	CFLAGS="$CFLAGS -Wall -std=gnu11"
-	CXXFLAGS="$CXXFLAGS -Wall " # -Weffc++" # TODO: enable when it does not print 1MB of warnings
+	CFLAGS="$CFLAGS -Wall"
 ])
 CFLAGS="$CFLAGS -D_GNU_SOURCE"
-CXXFLAGS="$CXXFLAGS -D_GNU_SOURCE"
 
 # =========================================================
 # Select a different shell instead of the default /bin/bash
@@ -411,7 +409,6 @@ AC_MSG_NOTICE([
 ==============================================================================
 Environment settings:
 	CFLAGS:                                    ${CFLAGS}
-	CXXFLAGS:                                  ${CXXFLAGS}
 	LDFLAGS:                                   ${LDFLAGS}
 Build configuration:
 	cups-config:     ${with_cups_config}


### PR DESCRIPTION
If we do not need C++ compiler, there should be no need to set the CXXFLAGS or print it during configure. Furthermore, forcing outdated C11 standard is not a good idea considering compilers have moved on. We should not limit our feature set, including compiler warnings, to old standards.

This is related to https://github.com/OpenPrinting/cups-filters/pull/504
