### PR TITLE
fix a SIGPIPE error when calling gs

### DIFF
--- a/filter/foomatic-rip/postscript.c
+++ b/filter/foomatic-rip/postscript.c
@@ -277,13 +277,17 @@ print_ps(FILE *file,
       }
     }
 
+    fclose(in);
+
     // If the input file has only a single page and the "showpage" is
     // very close to the end of the file, it cannot have been
     // discovered after the last bits of input data got
     // read. Therefore we do an extra check here.
     if (!pagefound)
     {
-      pres = poll(&pfd, 1, 1000);
+      // gs may have only started processing after we closed the input fd
+      // above, so give it a generous timeout.
+      pres = poll(&pfd, 1, 5000);
       if (pres < 0)
 	_log("Error reading Ghostscript output\n");
       else if (pres && (pfd.revents & POLLIN))
@@ -291,7 +295,6 @@ print_ps(FILE *file,
     }
 
     // Clean up and make Ghostscript stop by that
-    fclose(in);
     fclose(out);
     wait_for_process(pid);
 


### PR DESCRIPTION
https://autopkgtest.ubuntu.com/packages/f/foo2zjs/lunar/ppc64el shows foo2zjs's testsuite failing with cups-filters 2.0beta3 on ppc64el because the gs command here to check page count is failing with a SIGPIPE when trying to write back to the parent.  To fix this, we close gs's input fd as soon as we know we're done writing to it.  Since gs may not have started processing its input until this happens, also give the final poll() a longer timeout (5s instead of 1s); without this we see race conditions because foomatic-rip gives up before gs has had a chance to finish processing.