### PR TITLE
Enable application/vnd.cups-postscript in conversion tables

### DIFF
--- a/mime/cupsfilters-universal-postscript.convs
+++ b/mime/cupsfilters-universal-postscript.convs
@@ -32,6 +32,7 @@
 #
 
 application/postscript                   application/vnd.universal-input   0  -
+application/vnd.cups-postscript          application/vnd.universal-input   0  -
 
 # CUPS file conversion rules for PostScript input when we are working
 # with the PDF printing workflow: General PostScript input should be


### PR DESCRIPTION
Unfortunately there are filters which produce this MIME type (such as hpps from hplip), and if someone uses such driver on client and server has IPP Everywhere/driverless driver, job fails.

The patch (together with change in libcupsfilters, which will come later) fixes the issue.