### PR TITLE
braille: Fix finding tables from liblouis ≥3.21

### DIFF
--- a/filter/braille/filters/cups-braille.sh.in
+++ b/filter/braille/filters/cups-braille.sh.in
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015-2018 Samuel Thibault <samuel.thibault@ens-lyon.org>
+# Copyright (c) 2015-2018, 2023 Samuel Thibault <samuel.thibault@ens-lyon.org>
 # 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -353,10 +353,12 @@ getOptionLibLouis () {
       score=0
       name=${table#$TABLESDIR/}
 
-      if grep -q "^#+locale:$LOUIS_LOCALE$" $table; then
+      if grep -q "^#+locale: *$LOUIS_LOCALE$" $table || \
+         grep -q "^#+region: *$LOUIS_LOCALE$" $table ; then
 	printf "DEBUG: %s has correct locale %s\n" "$name" "$LOUIS_LOCALE" >&2
 	score=$((score + 15))
-      elif grep -q "^#+locale:$LANGUAGE$" $table; then
+      elif grep -q "^#+locale: *$LANGUAGE$" $table || \
+           grep -q "^#+language: *$LANGUAGE$" $table; then
 	printf "DEBUG: %s has correct language %s\n" "$name" "$LANGUAGE" >&2
 	score=$((score + 10))
       else


### PR DESCRIPTION
Since 3.21 (more precisely, commit e18fe140e2f1), liblouis uses language: and region: rather than locale: