### PR TITLE
configure: fix broken bashism resulting in logic failure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -349,7 +349,7 @@ AC_ARG_ENABLE([universal-cups-filter],
 	[enable_universal_cups_filter="$enableval"],
 	[enable_universal_cups_filter=yes]
 )
-AS_IF([test "x$CUPS_GHOSTSCRIPT" == "x" -a "x$CUPS_PDFTOPS" == "x"], [
+AS_IF([test "x$CUPS_GHOSTSCRIPT" = "x" -a "x$CUPS_PDFTOPS" = "x"], [
 	enable_universal_cups_filter=no
 ])
 AM_CONDITIONAL([ENABLE_UNIVERSAL_CUPS_FILTER],


### PR DESCRIPTION
After carefully using configure checks designed to work on pre-unix wars bourne shells -- that is, the `test "$var" = ""` construct once upon a time wasn't specified to treat "" as a distinct argument, so the "x" padding provided a guaranteed comparison -- the configure.ac check then fails to run on any shells at all other than GNU bash.

Bash provides the standard `test XXX = YYY` or `[ XXX = YYY ]` utilities. It also provides the ability to spell the equals sign as a double equals. This does nothing whatsoever -- it adds no new functionality to bash, it forbids nothing, it is *literally* an exact alias.

It should never be used under any circumstances. All developers must immediately forget that it exists. Using it is non-portable and does not work in /bin/sh scripts such as configure scripts, and it results in dangerous muscle memory when used in bash scripts because it makes people unthinkingly use the double equals even in /bin/sh scripts. To add insult to injury, it makes scripts take up more disk space (by a whole byte! and sometimes even a few bytes...)

Delete this accidental bashism, and restore the ability to get correct ./configure behavior on systems where /bin/sh is something other than a symlink to GNU bash.