### PR TITLE
Backport data stream concatenation fix from libcupsfilters

### DIFF
--- a/filter/pdftopdf/qpdf_xobject.cc
+++ b/filter/pdftopdf/qpdf_xobject.cc
@@ -29,8 +29,10 @@ void CombineFromContents_Provider::provideStreamData(int objid, int generation, 
 {
   Pl_Concatenate concat("concat", pipeline);
   const int clen=contents.size();
-  for (int iA=0;iA<clen;iA++) {
+  for (int iA=0;iA<clen;iA++)
+  {
     contents[iA].pipeStreamData(&concat, true, false, false);
+    concat << "\n";
   }
   concat.manualFinish();
 }


### PR DESCRIPTION
Backport of fix [#56](https://github.com/OpenPrinting/libcupsfilters/pull/56/) in libcupsfilters to branch 1.x.