### PR TITLE
pclmtoraster: Properly set CFLAGS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -371,7 +371,7 @@ imagetoraster_LDADD = \
 
 pclmtoraster_SOURCES = \
 	filter/pclmtoraster.c
-pclmtoraster_CXXFLAGS = \
+pclmtoraster_CFLAGS = \
 	$(LIBCUPSFILTERS_CFLAGS) \
 	$(LIBPPD_CFLAGS) \
 	$(CUPS_CFLAGS)


### PR DESCRIPTION
As this is a C program, set
`pclmtoraster_CFLAGS`, not `pclmtoraster_CXXFLAGS`.

This fixes building pclmtoraster when libcupsfilter headers are installed in a non-standard directory.

Previously, when configuring and installing libcupsfilters with e.g. `--prefix=$HOME/temp/cpdb` and then configuring cups-filters with `PKG_CONFIG_PATH=$HOME/temp/cpdb/lib/pkgconfig/`, `make pclmtoraster` would fail like this:

      CC       filter/pclmtoraster.o
    filter/pclmtoraster.c:14:10: fatal error: cupsfilters/filter.h: No such file or directory
       14 | #include <cupsfilters/filter.h>
          |          ^~~~~~~~~~~~~~~~~~~~~~
    compilation terminated.

For this to actually work, recent libcupsfilters
commit [1] is also needed:

    commit 449ac6350d00c385ae226513ef6d85ee81ae161a
    Author: Michael Weghorn <m.weghorn@posteo.de>
    Date:   Thu Jul 4 14:44:26 2024 +0200

        pkgconfig: Add '-I${includedir}' to Cflags (#57)

[1] https://github.com/OpenPrinting/libcupsfilters/commit/449ac6350d00c385ae226513ef6d85ee81ae161a