### PR TITLE
braille: Fix picking locale from newer liblouis files

### DIFF
--- a/filter/braille/filters/cups-braille.sh.in
+++ b/filter/braille/filters/cups-braille.sh.in
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015-2018 Samuel Thibault <samuel.thibault@ens-lyon.org>
+# Copyright (c) 2015-2018, 2024 Samuel Thibault <samuel.thibault@ens-lyon.org>
 # 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -356,7 +356,13 @@ getOptionLibLouis () {
       if grep -q "^#+locale:$LOUIS_LOCALE$" $table; then
 	printf "DEBUG: %s has correct locale %s\n" "$name" "$LOUIS_LOCALE" >&2
 	score=$((score + 15))
+      elif grep -q "^#+region:$LOUIS_LOCALE$" $table; then
+	printf "DEBUG: %s has correct region %s\n" "$name" "$LOUIS_LOCALE" >&2
+	score=$((score + 15))
       elif grep -q "^#+locale:$LANGUAGE$" $table; then
+	printf "DEBUG: %s has correct language %s\n" "$name" "$LANGUAGE" >&2
+	score=$((score + 10))
+      elif grep -q "^#+language:$LANGUAGE$" $table; then
 	printf "DEBUG: %s has correct language %s\n" "$name" "$LANGUAGE" >&2
 	score=$((score + 10))
       else

--- a/filter/braille/filters/liblouis1.defs.gen.in
+++ b/filter/braille/filters/liblouis1.defs.gen.in
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # 
-# Copyright (c) 2015, 2017-2018, 2020 Samuel Thibault <samuel.thibault@ens-lyon.org>
+# Copyright (c) 2015, 2017-2018, 2020, 2024 Samuel Thibault <samuel.thibault@ens-lyon.org>
 # 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -232,9 +232,12 @@ echo '  Choice "HyphLocale/Default hyphenation rules for language" ""'
 	"zh-hk")	LANGUAGE=Chinese LOCATION="Hong Kong" TYPE="grade 1" ;;
 	"zh-tw")	LANGUAGE=Chinese LOCATION="Taiwan" TYPE="grade 1" ;;
 	"zh-chn")	LANGUAGE=Chinese LOCATION="China" TYPE="grade 1" ;;
-	*)		locale=$(grep ^#+locale: "$i" | cut -d ':' -f 2-)
+	*)		locale=$(grep -e '^#+\(locale\|region\):' "$i" | cut -d ':' -f 2-)
+			language=$(grep ^#+language: "$i" | cut -d ':' -f 2-)
 			if [ -n "$locale" ]; then
 			  LANGUAGE="$locale"
+			elif [ -n "$language" ]; then
+			  LANGUAGE="$language"
 			fi
 			if [ $ext = ctb ]; then
 			  TYPE="contracted"


### PR DESCRIPTION
Since version 3.21.0 liblouis uses language/region instead of locale.