### PR TITLE
pdftopdf: do not generate extra blank page for page-set=even (#541)

### DIFF
--- a/filter/pdftopdf/pdftopdf_processor.cc
+++ b/filter/pdftopdf/pdftopdf_processor.cc
@@ -333,7 +333,7 @@ bool processPDFTOPDF(PDFTOPDF_Processor &proc,ProcessingParameters &param) // {{
 
     bool newPage=nupstate.nextPage(rect.width,rect.height,pgedit);
     if (newPage) {
-      if ((curpage)&&(param.withPage(outputpage))) {
+      if (curpage && (param.withPage(outputpage) || (numOrigPages == 1 && !param.oddPages))) {
 	curpage->rotate(param.orientation);
 	if (param.mirror)
 	  curpage->mirror();
@@ -397,7 +397,7 @@ bool processPDFTOPDF(PDFTOPDF_Processor &proc,ProcessingParameters &param) // {{
 
     // pgedit.dump();
   }
-  if ((curpage)&&(param.withPage(outputpage))) {
+  if (curpage && (param.withPage(outputpage) || (numOrigPages == 1 && !param.oddPages))) {
     curpage->rotate(param.orientation);
     if (param.mirror) {
       curpage->mirror();
@@ -409,7 +409,7 @@ bool processPDFTOPDF(PDFTOPDF_Processor &proc,ProcessingParameters &param) // {{
       fprintf(stderr, "PAGE: %d %d\n", outputno, param.copies_to_be_logged);
   }
 
-  if ((param.evenDuplex || !param.oddPages) && (outputno & 1)) {
+  if (param.evenDuplex && (outputno & 1)) {
     // need to output empty page to not confuse duplex
     proc.add_page(proc.new_page(param.page.width,param.page.height),param.reverse);
     // Log page in /var/log/cups/page_log


### PR DESCRIPTION
Since commit 686a28d pdftopdf started to insert extra blank page when printing even-paged documents in page-set=even mode. This was the attempt to fix two issues at once:

* [Print 1-page documents in even mode][1]
* Treat non-duplex even reverse printing as second step of manual duplex

Unfortunately due to inverted logic this didn't fix any issues and introduced new one, outlined above.

This code fixes printing 1-page documents in even mode, and prints exactly what the user requested in even mode for larger documents, without inserting extra blank pages.

[1]: https://bugs.launchpad.net/ubuntu/+source/cups-filters/+bug/1340435