### PR TITLE
Add MIME Type Definitions for JPEG‑XL Support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -117,6 +117,15 @@ AC_SUBST(CUPS_SERVERBIN)
 # ========================
 PKG_CHECK_MODULES([LIBCUPSFILTERS], [libcupsfilters])
 
+======================
+# Check for libjxl (JPEG-XL)
+# ======================
+PKG_CHECK_MODULES([LIBJXL], [libjxl >= 0.7.0],
+  [have_libjxl=yes],
+  [have_libjxl=no]
+)
+AM_CONDITIONAL([HAVE_LIBJXL], [test "x$have_libjxl" = "xyes"])
+
 # ================
 # Check for libppd
 # ================
@@ -373,6 +382,9 @@ AC_DEFINE_UNQUOTED([SHELL], "$with_shell", [Path for a modern shell])
 AC_CONFIG_FILES([
 	Makefile
 	filter/foomatic-rip/foomatic-rip.1
+	data/cupsfilters.types
+	data/cupsfilters-individual.convs
+	data/cupsfilters-universal.convs
 ])
 AC_OUTPUT
 

--- a/configure.ac
+++ b/configure.ac
@@ -382,9 +382,9 @@ AC_DEFINE_UNQUOTED([SHELL], "$with_shell", [Path for a modern shell])
 AC_CONFIG_FILES([
 	Makefile
 	filter/foomatic-rip/foomatic-rip.1
-	data/cupsfilters.types
-	data/cupsfilters-individual.convs
-	data/cupsfilters-universal.convs
+	mime/cupsfilters.types
+	mime/cupsfilters-individual.convs
+	mime/cupsfilters-universal.convs
 ])
 AC_OUTPUT
 

--- a/configure.ac
+++ b/configure.ac
@@ -382,9 +382,6 @@ AC_DEFINE_UNQUOTED([SHELL], "$with_shell", [Path for a modern shell])
 AC_CONFIG_FILES([
 	Makefile
 	filter/foomatic-rip/foomatic-rip.1
-	mime/cupsfilters.types
-	mime/cupsfilters-individual.convs
-	mime/cupsfilters-universal.convs
 ])
 AC_OUTPUT
 

--- a/mime/cupsfilters-individual.convs
+++ b/mime/cupsfilters-individual.convs
@@ -43,7 +43,7 @@ text/plain		application/pdf				32	texttopdf
 image/pwg-raster	application/pdf				32	pwgtopdf
 image/png		application/vnd.cups-pdf		65	imagetopdf
 image/jpeg		application/vnd.cups-pdf		65	imagetopdf
-image/jxl		application/vnd.cups-pdf		65	imagetopdf
+@HAVE_LIBJXL_TRUE@image/jxl		application/vnd.cups-pdf		65	imagetopdf
 image/tiff		application/vnd.cups-pdf		65	imagetopdf
 application/vnd.cups-pdf-banner	application/pdf			32	bannertopdf
 image/urf		application/pdf				0	pwgtopdf
@@ -76,7 +76,7 @@ application/vnd.adobe-reader-postscript	application/vnd.cups-postscript	66	pstop
 application/PCLm		application/vnd.cups-raster	32	pclmtoraster
 image/png			application/vnd.cups-raster	100	imagetoraster
 image/jpeg			application/vnd.cups-raster	100	imagetoraster
-image/jxl			application/vnd.cups-raster	100	imagetoraster
+@HAVE_LIBJXL_TRUE@image/jxl			application/vnd.cups-raster	100	imagetoraster
 image/tiff			application/vnd.cups-raster	100	imagetoraster
 image/pwg-raster		application/vnd.cups-raster	100	pwgtoraster
 image/urf			application/vnd.cups-raster	100	pwgtoraster

--- a/mime/cupsfilters-individual.convs
+++ b/mime/cupsfilters-individual.convs
@@ -43,6 +43,7 @@ text/plain		application/pdf				32	texttopdf
 image/pwg-raster	application/pdf				32	pwgtopdf
 image/png		application/vnd.cups-pdf		65	imagetopdf
 image/jpeg		application/vnd.cups-pdf		65	imagetopdf
+image/jxl		application/vnd.cups-pdf		65	imagetopdf
 image/tiff		application/vnd.cups-pdf		65	imagetopdf
 application/vnd.cups-pdf-banner	application/pdf			32	bannertopdf
 image/urf		application/pdf				0	pwgtopdf
@@ -75,6 +76,7 @@ application/vnd.adobe-reader-postscript	application/vnd.cups-postscript	66	pstop
 application/PCLm		application/vnd.cups-raster	32	pclmtoraster
 image/png			application/vnd.cups-raster	100	imagetoraster
 image/jpeg			application/vnd.cups-raster	100	imagetoraster
+image/jxl			application/vnd.cups-raster	100	imagetoraster
 image/tiff			application/vnd.cups-raster	100	imagetoraster
 image/pwg-raster		application/vnd.cups-raster	100	pwgtoraster
 image/urf			application/vnd.cups-raster	100	pwgtoraster

--- a/mime/cupsfilters-universal.convs
+++ b/mime/cupsfilters-universal.convs
@@ -32,7 +32,7 @@
 #
 
 image/jpeg                      application/vnd.universal-input      0    -
-image/jxl                       application/vnd.universal-input      0    -
+@HAVE_LIBJXL_TRUE@image/jxl     application/vnd.universal-input      0    -
 image/png                       application/vnd.universal-input      0    -
 image/tiff                      application/vnd.universal-input      0    -
 image/pwg-raster                application/vnd.universal-input      0    -

--- a/mime/cupsfilters-universal.convs
+++ b/mime/cupsfilters-universal.convs
@@ -32,6 +32,7 @@
 #
 
 image/jpeg                      application/vnd.universal-input      0    -
+image/jxl                       application/vnd.universal-input      0    -
 image/png                       application/vnd.universal-input      0    -
 image/tiff                      application/vnd.universal-input      0    -
 image/pwg-raster                application/vnd.universal-input      0    -

--- a/mime/cupsfilters.types
+++ b/mime/cupsfilters.types
@@ -91,6 +91,8 @@ image/x-xbitmap			xbm string(0,"#define");
 image/x-xpixmap			xpm string(3,"XPM")
 image/x-xwindowdump		xwd string(4,<00000007>)
 image/urf			urf string(0,UNIRAST<00>)
+image/jxl       		jxl string(0,"<0000000C4A584C20>") priority(150)
+
 
 ########################################################################
 #

--- a/mime/cupsfilters.types
+++ b/mime/cupsfilters.types
@@ -91,8 +91,8 @@ image/x-xbitmap			xbm string(0,"#define");
 image/x-xpixmap			xpm string(3,"XPM")
 image/x-xwindowdump		xwd string(4,<00000007>)
 image/urf			urf string(0,UNIRAST<00>)
-image/jxl       		jxl string(0,<0000000C4A584C20>)
-image/jxl			jxl string(0,<FF0A>)
+image/jxl       		jxl string(0,"<0000000C4A584C20>")
+image/jxl			jxl string(0,"<FF0A>")
 
 
 ########################################################################

--- a/mime/cupsfilters.types
+++ b/mime/cupsfilters.types
@@ -92,6 +92,7 @@ image/x-xpixmap			xpm string(3,"XPM")
 image/x-xwindowdump		xwd string(4,<00000007>)
 image/urf			urf string(0,UNIRAST<00>)
 image/jxl       		jxl string(0,<0000000C4A584C20>)
+image/jxl			jxl string(0,<FF0A>)
 
 
 ########################################################################

--- a/mime/cupsfilters.types
+++ b/mime/cupsfilters.types
@@ -91,8 +91,7 @@ image/x-xbitmap			xbm string(0,"#define");
 image/x-xpixmap			xpm string(3,"XPM")
 image/x-xwindowdump		xwd string(4,<00000007>)
 image/urf			urf string(0,UNIRAST<00>)
-image/jxl       		jxl string(0,"<0000000C4A584C20>") string(0,"<FF0A>")
-
+@HAVE_LIBJXL_TRUE@image/jxl	jxl string(0,"<0000000C4A584C20>") string(0,"<FF0A>")
 
 ########################################################################
 #

--- a/mime/cupsfilters.types
+++ b/mime/cupsfilters.types
@@ -91,7 +91,7 @@ image/x-xbitmap			xbm string(0,"#define");
 image/x-xpixmap			xpm string(3,"XPM")
 image/x-xwindowdump		xwd string(4,<00000007>)
 image/urf			urf string(0,UNIRAST<00>)
-image/jxl       		jxl string(0,"<0000000C4A584C20>") priority(150)
+image/jxl       		jxl string(0,<0000000C4A584C20>)
 
 
 ########################################################################

--- a/mime/cupsfilters.types
+++ b/mime/cupsfilters.types
@@ -91,8 +91,7 @@ image/x-xbitmap			xbm string(0,"#define");
 image/x-xpixmap			xpm string(3,"XPM")
 image/x-xwindowdump		xwd string(4,<00000007>)
 image/urf			urf string(0,UNIRAST<00>)
-image/jxl       		jxl string(0,"<0000000C4A584C20>")
-image/jxl			jxl string(0,"<FF0A>")
+image/jxl       		jxl string(0,"<0000000C4A584C20>") string(0,"<FF0A>")
 
 
 ########################################################################


### PR DESCRIPTION
This pull request introduces new MIME type definitions and conversion rules to enable proper recognition of JPEG‑XL files in cups‑filters. With these changes, CUPS and associated utilities (e.g. cupsfilter) will be able to correctly identify and process JPEG‑XL files based on their content and file extension.

> **Note:** This PR is limited to MIME type contributions only and does not include changes to image decoding or filter implementations.

---

## Changes Overview

### MIME Types
- **File Modified:** `mime/cupsfilters.types`
  - Added a new MIME type entry for JPEG‑XL:
  - The rule uses a magic signature check (for both the standard signature and the stream signature) to detect JPEG‑XL files. The `priority(150)` was added to ensure that this MIME type has a higher priority compared to similar image formats, so that JPEG‑XL files are correctly identified.

### MIME Conversion Rules
- **Files Modified:** Various conversion files (e.g., `cupsfilters-individual.convs`, `cupsfilters.convs`, etc.)
  - Conversion rules have been updated or added to map the new MIME type (`image/jxl`) to the appropriate filter chains.
  - The changes ensure that JPEG‑XL files follow the same processing workflow as other supported image formats (such as JPEG), allowing for proper conversion to PDF, raster, or other output formats.

---

## Testing and Verification

- **Local Tests:**
  - Verified that sample JPEG‑XL files are now correctly identified as `image/jxl` by checking with MIME detection tools.
  - Ran the `cupsfilter` utility and confirmed that the new MIME type rules enable proper file detection.
- **Integration:** Ensured that the modifications do not disrupt processing of other image formats.

---

## Future Work

- **Further Refinement:** Monitor the behavior of the new MIME type rules in various deployment scenarios and refine the signature/magic string checks if needed.
- **Documentation Updates:** Update any user or administrator documentation to mention the new support for JPEG‑XL MIME types.
- **Community Feedback:** Open to suggestions for improving MIME type definitions based on feedback from the user and developer communities.

---

## Background

This contribution is part of my ongoing work to modernize image format support in cups‑filters. I originally contributed MIME type modifications during the WoC 5.0 event organized by IIIT Kalyani, and I look forward to continuing my contributions to further enhance the project.

**GitHub Repository:** [https://github.com/TitikshaBansal/cups-filters](https://github.com/TitikshaBansal/cups-filters)  
**Branch:** `features/jpegxl-mime-support`

---

Thank you for your review. I look forward to any feedback and suggestions for further improvements.

Best regards,  
*Titiksha Bansal*