### PR TITLE
image-zoom.c: add the xsize and ysize check to zero in _cupsImageZoomNew

### DIFF
--- a/cupsfilters/image-zoom.c
+++ b/cupsfilters/image-zoom.c
@@ -94,8 +94,9 @@ _cupsImageZoomNew(
   if (xsize > CUPS_IMAGE_MAX_WIDTH ||
       ysize > CUPS_IMAGE_MAX_HEIGHT ||
       (xc1 - xc0) > CUPS_IMAGE_MAX_WIDTH ||
-      (yc1 - yc0) > CUPS_IMAGE_MAX_HEIGHT)
-    return (NULL);		/* Protect against integer overflow */
+      (yc1 - yc0) > CUPS_IMAGE_MAX_HEIGHT ||
+      xsize == 0 || ysize == 0)
+    return (NULL);		/* Protect against integer overflow and divide by zero */
 
   if ((z = (cups_izoom_t *)calloc(1, sizeof(cups_izoom_t))) == NULL)
     return (NULL);

--- a/filter/imagetoraster.c
+++ b/filter/imagetoraster.c
@@ -1437,6 +1437,8 @@ main(int  argc,				/* I - Number of command-line arguments */
 	    z = _cupsImageZoomNew(img, xc0, yc0, xc1, yc1, xtemp, ytemp,
 	                          Orientation & 1, zoom_type);
 
+          if (z == NULL) continue;
+
          /*
 	  * Write leading blank space as needed...
 	  */


### PR DESCRIPTION
When calculating z->xmod, z->xstep, etc., if xsize and ysize are zero, division by zero occurs. To avoid this, the xsize and ysize check for zero is added at the beginning of the function.