### PR TITLE
Add a configure option for texttopdf filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ m4/ltsugar.m4
 m4/ltversion.m4
 m4/lt~obsolete.m4
 mime/cupsfilters.convs
+mime/cupsfilters-individual.convs
 utils/driverless-fax
 beh
 parallel

--- a/Makefile.am
+++ b/Makefile.am
@@ -195,7 +195,6 @@ pkgfilter_PROGRAMS += \
 endif
 pkgfilter_PROGRAMS += \
 	pdftops \
-	texttopdf \
 	pwgtopclm \
 	pwgtopdf \
 	bannertopdf \
@@ -209,6 +208,10 @@ endif
 if ENABLE_PSTOPS
 pkgfilter_PROGRAMS += \
 	pstops
+endif
+if ENABLE_TEXTTOPDF
+pkgfilter_PROGRAMS += \
+	texttopdf
 endif
 if ENABLE_POPPLER
 pkgfilter_PROGRAMS += \

--- a/configure.ac
+++ b/configure.ac
@@ -305,6 +305,16 @@ AC_ARG_ENABLE([pstops],
 )
 AM_CONDITIONAL([ENABLE_PSTOPS], [test "x$enable_pstops" = "xyes"])
 
+# ===================
+# Check for texttopdf
+# ===================
+AC_ARG_ENABLE([texttopdf],
+	[AS_HELP_STRING([--disable-texttopdf], [Disable the texttopdf filter.])],
+	[enable_texttopdf="$enableval"],
+	[enable_texttopdf=yes]
+)
+AM_CONDITIONAL([ENABLE_TEXTTOPDF], [test "x$enable_texttopdf" = "xyes"])
+
 # =====================
 # Check for rastertopwg
 # =====================
@@ -395,6 +405,7 @@ Build configuration:
 	ippfind-path:    ${with_ippfind_path}
 	imagefilters:    ${enable_imagefilters}
 	pstops:          ${enable_pstops}
+	texttopdf:       ${enable_texttopdf}
 	rastertopwg:     ${enable_rastertopwg}
 	shell:           ${with_shell}
 	universal CUPS filter: ${enable_universal_cups_filter}

--- a/configure.ac
+++ b/configure.ac
@@ -383,6 +383,7 @@ AC_DEFINE_UNQUOTED([SHELL], "$with_shell", [Path for a modern shell])
 AC_CONFIG_FILES([
 	Makefile
 	filter/foomatic-rip/foomatic-rip.1
+	mime/cupsfilters-individual.convs
 ])
 AC_OUTPUT
 

--- a/mime/cupsfilters-individual.convs.in
+++ b/mime/cupsfilters-individual.convs.in
@@ -39,7 +39,7 @@
 #
 
 application/pdf		application/vnd.cups-pdf		66	pdftopdf
-text/plain		application/pdf				32	texttopdf
+@ENABLE_TEXTTOPDF_TRUE@text/plain		application/pdf				32	texttopdf
 image/pwg-raster	application/pdf				32	pwgtopdf
 image/png		application/vnd.cups-pdf		65	imagetopdf
 image/jpeg		application/vnd.cups-pdf		65	imagetopdf


### PR DESCRIPTION
Add `--enable-texttopdf` and `--disable-texttopdf` configure options to determine whether to build this filter or not (and add the associated mime conversion type).  If this option is not specified, the default will be to build this filter (so this works the same prior to this change).

See https://github.com/OpenPrinting/libcupsfilters/pull/83 for a related change in libcupsfilters.