### PR TITLE
image-sgi: Return early if sgiOpenFile fails

### DIFF
--- a/cupsfilters/image-sgi.c
+++ b/cupsfilters/image-sgi.c
@@ -56,6 +56,9 @@ _cupsImageReadSGI(
 
   sgip = sgiOpenFile(fp, SGI_READ, 0, 0, 0, 0, 0);
 
+  if (!sgip)
+    return (1);
+
  /*
   * Get the image dimensions and load the output image...
   */


### PR DESCRIPTION
sgiOpenFile can fail when passing an image that both has large dimensions and which also uses RLE compression.  In that case, sgiOpenFile attempts to allocate space for compression-related tables and these allocations may fail due to the requested size, causing sgiOpenFile to return NULL.  Without this fix, the NULL pointer gets dereferenced, which crashes the filter process.

Compare https://en.wikipedia.org/wiki/Silicon_Graphics_Image#Header for an overview of the SGI image headere.