### PR TITLE
foomatic-rip: `rip_die()` did not relay error to cupsd

### DIFF
--- a/filter/foomatic-rip/util.c
+++ b/filter/foomatic-rip/util.c
@@ -76,7 +76,7 @@ rip_die(int status,
 {
   va_list ap;
 
-  _log("Process is dying with \"");
+  _log("ERROR: Process is dying with \"");
   va_start(ap, msg);
   _logv(msg, ap);
   va_end(ap);


### PR DESCRIPTION
The function which is used to report error was using incorrect format for cupsd to process it as error, causing hiding its error messages.