### PR TITLE
Clarify Poppler grayscale warning message. Fixes #640

### DIFF
--- a/README
+++ b/README
@@ -164,6 +164,12 @@ POSTSCRIPT PRINTING RENDERER AND RESOLUTION SELECTION
     generating PostScript level 1. So its support is only experimental
     and distributions should not choose it as default.
 
+    Poppler does not explicitly support turning colored PDF files into
+    grayscale PostScript, that's why grayscale/monochrome printing
+    could result in color output.
+    Use alternative backends, such as Ghostscript or MuPDF, if this is
+    the case with your printer.
+
     The selection is done by the "pdftops-renderer" option, setting it
     to "gs", "pdftops", "pdftocairo", "acroread", "mupdf", or "hybrid":
 

--- a/filter/pdftops.c
+++ b/filter/pdftops.c
@@ -924,8 +924,7 @@ main(int  argc,				/* I - Number of command-line args */
       /* pdf_argv[1] = (char *)"-level1";
 	 pdf_argv[pdf_argc++] = (char *)"-optimizecolorspace"; */
       /* Issue a warning message when printing a grayscale job with Poppler */
-      fprintf(stderr, "WARNING: Grayscale/monochrome printing requested for this job but Poppler is not able to convert to grayscale/monochrome PostScript.\n");
-      fprintf(stderr, "WARNING: Use \"pdftops-renderer\" option (see cups-filters README file) to use Ghostscript or MuPDF for the PDF -> PostScript conversion.\n");
+      fprintf(stderr, "WARNING: Grayscale/monochrome could be printed as color with Poppler. See cups-filters README file (\"pdftops-renderer\" option).\n");
     }
     pdf_argv[pdf_argc++] = filename;
     pdf_argv[pdf_argc++] = (char *)"-";


### PR DESCRIPTION
Many printer queue viewers show only the latest status message while printing, which results in confusing message when using Poppler pdftops backend when printing:

>Use "pdftops-renderer" option (see cups-filters README file) to use Ghostscript or MuPDF for the PDF -> PostScript conversion.

And the first line is omitted.

Simplify the text and add more details into cups-filters readme.

#640 