### PR TITLE
pdftopdf qpdf: Silence QPDF warnings

### DIFF
--- a/filter/pdftopdf/qpdf_pdftopdf_processor.cc
+++ b/filter/pdftopdf/qpdf_pdftopdf_processor.cc
@@ -491,6 +491,7 @@ bool QPDF_PDFTOPDF_Processor::loadFile(FILE *f,ArgOwnership take,int flatten_for
   case WillStayAlive:
     try {
       pdf->processFile("temp file",f,false);
+      pdf->setSuppressWarnings(true);
     } catch (const std::exception &e) {
       error("loadFile failed: %s",e.what());
       return false;
@@ -499,6 +500,7 @@ bool QPDF_PDFTOPDF_Processor::loadFile(FILE *f,ArgOwnership take,int flatten_for
   case TakeOwnership:
     try {
       pdf->processFile("temp file",f,true);
+      pdf->setSuppressWarnings(true);
     } catch (const std::exception &e) {
       error("loadFile failed: %s",e.what());
       return false;
@@ -519,6 +521,7 @@ bool QPDF_PDFTOPDF_Processor::loadFilename(const char *name,int flatten_forms) /
   try {
     pdf.reset(new QPDF);
     pdf->processFile(name);
+    pdf->setSuppressWarnings(true);
   } catch (const std::exception &e) {
     error("loadFilename failed: %s",e.what());
     return false;


### PR DESCRIPTION
Silence QPDF warnings for PDFs especially those generated by macOS (Quartz) as they are re-interpreted by macOS CUPS clients as errors:
- file is damaged
- (object XX 0): object has offset 0
- (object XX 0): expected XX 0 obj
- object XX 0 not found in file after regenerating cross reference table
- Attempting to reconstruct cross-reference table

see:
https://github.com/OpenPrinting/cups/issues/321

From https://github.com/dkosovic/cups