### PR TITLE
foomatic-rip: Allocate modern_shell dynamically

### DIFF
--- a/filter/foomatic-rip/process.c
+++ b/filter/foomatic-rip/process.c
@@ -22,7 +22,7 @@
 
 int kidgeneration = 0;
 
-char modern_shell[] = SHELL;
+char *modern_shell;
 
 struct process
 {

--- a/filter/foomatic-rip/process.h
+++ b/filter/foomatic-rip/process.h
@@ -18,7 +18,7 @@
 #include <sys/wait.h>
 
 
-extern char modern_shell[];
+extern char *modern_shell;
 
 pid_t start_process(const char *name, int (*proc_func)(FILE*, FILE*, void*), void *user_arg,
 		    FILE **fdin, FILE **fdout);

--- a/filter/foomatic-rip/util.c
+++ b/filter/foomatic-rip/util.c
@@ -84,6 +84,7 @@ rip_die(int status,
 
   _log("Cleaning up...\n");
   kill_all_processes();
+  free(modern_shell);
 
   exit(status);
 }


### PR DESCRIPTION
Modern shell value can change during runtime, we should allocate dynamically.