### PR TITLE
Ghostscript (gstoraster): new halftone/dithering algorithms

### DIFF
--- a/README
+++ b/README
@@ -122,6 +122,54 @@ GHOSTSCRIPT RENDERING OF FILLED PATHS
    This option can be used when the print queue uses the gstoraster
    filter.
 
+GHOSTSCRIPT RENDERING: HALFTONING AND DITHERING
+
+    When using gstoX filters, it's possible to control halftone screens
+    and dithering using "-o halftone-type=XXX" command line job option or
+    "cupsHalftoneType" PPD option.
+
+    Ghostscript uses the following default auto-detection:
+    * DPI <  150: 8x8 ordered dithering
+    * DPI >= 150: Horn's cosine line halftoning with screen angle 45 deg
+
+    with "-o halftone-type=XXX", you can use other algorithms with
+    additional options.
+
+    Algorithms available:
+    * -o halftone-type=bi-level, simple black-or-white threshold,
+         best suited for label printers
+    * -o halftone-type=stochastic (also =yes), stochastic threshold-array
+         halftoning
+    * -o halftone-type=foo2zjs, high-quality per-color halftone screen,
+         best for laser/ink printers, with the following configuration:
+          Frequency=150,
+          Angle=105 (Cyan), 165 (Magenta), 30 (Yellow), 45 (Black), 37 (def),
+          Spot Function=CosineDot
+    * -o halftone-type=dithering, forces 8x8 ordered dithering
+    * -o halftone-type=genordered[-frequency][-angle][-dotshape]
+    * -o halftone-type=spot[-frequency][-angle][-dotshape]
+
+    genordered is a halftone+ordered dithering algorithm,
+      frequency - line-per-inch, number of halftone cells per inch.
+                  Lower produces larger dots, higher - smaller.
+                  Values good for 203DPI label printer: 50-60
+                                  600DPI laser printer: 106-150
+      angle - screen orientation, in degrees.
+      dotshape - one of:
+        0=CIRCLE, 1=REDBOOK, 2=INVERTED, 3=RHOMBOID, 4=LINE_X, 5=LINE_Y,
+        6=DIAMOND1, 7=DIAMOND2, 8=ROUNDSPOT
+
+    spot is a halftone algorithm from PDF specification,
+      frequency, angle - same as for genordered
+      dotshape - one of:
+        0=SimpleDot 1=InvertedSimpleDot 2=DoubleDot 3=InvertedDoubleDot
+        4=CosineDot 5=Double 6=InvertedDouble 7=Line 8=LineX 9=LineY 10=Round
+        11=Ellipse 12=EllipseA 13=InvertedEllipseA 14=EllipseB 15=EllipseC
+        16=InvertedEllipseC 17=Square 18=Cross 19=Rhomboid 20=Diamond
+
+    Algorithm could be selected per-queue, for example:
+      lpadmin -p printer -o halftone-type-default=genordered-150-45
+
 POSTSCRIPT PRINTING RENDERER AND RESOLUTION SELECTION
 
     If you use CUPS with this package and a PostScript printer then

--- a/filter/gstoraster.c
+++ b/filter/gstoraster.c
@@ -69,7 +69,8 @@ typedef enum
   HALFTONE_DEFAULT,
   HALFTONE_STOCHASTIC,
   HALFTONE_FOO2ZJS,
-  HALFTONE_BI_LEVEL
+  HALFTONE_BI_LEVEL,
+  HALFTONE_DITHERING
 } cups_halftone_type_t;
 
 #ifdef CUPS_RASTER_SYNCv1
@@ -1000,6 +1001,8 @@ main (int argc, char **argv, char *envp[])
       halftonetype = HALFTONE_FOO2ZJS;
     else if (!strcasecmp(halftone_tmp, "bi-level"))
       halftonetype = HALFTONE_BI_LEVEL;
+    else if (!strcasecmp(halftone_tmp, "dithering"))
+      halftonetype = HALFTONE_DITHERING;
   }
 
   /* For bi-level type, also check print-color-mode, the way it is
@@ -1108,6 +1111,22 @@ main (int argc, char **argv, char *envp[])
   if (halftonetype == HALFTONE_BI_LEVEL) {
     fprintf(stderr, "DEBUG: Ghostscript using Bi-Level Halftone dithering.\n");
     cupsArrayAdd(gs_args, strdup("{ .5 gt { 1 } { 0 } ifelse} settransfer"));
+  }
+
+  /* Use 8x8 ordered dithering.
+   *
+   * This uses .setloresscreen Ghostscript setup function which is a part
+   * of dithering vs halftoning automatic selection code and is used only
+   * if DPI of the output device is low (< 150).
+   * To correctly force it, we need to call it in Install function of
+   * Page Device.
+   * DPI is auto-detected and passed for screen frequency calculation.
+   *
+   * Particularly useful for printing images on label printers (203 DPI).
+   */
+  if (halftonetype == HALFTONE_DITHERING) {
+    fprintf(stderr, "DEBUG: Ghostscript using 8x8 ordered dithering.\n");
+    cupsArrayAdd(gs_args, strdup("<< /Install { 72 72 matrix defaultmatrix dtransform abs exch abs .min .setloresscreen } >> setpagedevice"));
   }
 
   /* Mark the end of PostScript commands supplied on the Ghostscript command

--- a/filter/gstoraster.c
+++ b/filter/gstoraster.c
@@ -70,7 +70,8 @@ typedef enum
   HALFTONE_STOCHASTIC,
   HALFTONE_FOO2ZJS,
   HALFTONE_BI_LEVEL,
-  HALFTONE_DITHERING
+  HALFTONE_DITHERING,
+  HALFTONE_GENORDERED
 } cups_halftone_type_t;
 
 #ifdef CUPS_RASTER_SYNCv1
@@ -658,6 +659,7 @@ main (int argc, char **argv, char *envp[])
   int pxlcolor = 1;
   cups_halftone_type_t halftonetype = HALFTONE_DEFAULT;
   char *halftone_tmp = NULL;
+  int ht_frequency = 133, ht_angle = 45, ht_dotshape = 0;
 #ifdef HAVE_CUPS_1_7
   int pwgraster = 0;
   ppd_attr_t *attr;
@@ -1003,6 +1005,27 @@ main (int argc, char **argv, char *envp[])
       halftonetype = HALFTONE_BI_LEVEL;
     else if (!strcasecmp(halftone_tmp, "dithering"))
       halftonetype = HALFTONE_DITHERING;
+    else if (!strncasecmp(halftone_tmp, "genordered", 10) &&
+             (halftone_tmp[10] == '-' || halftone_tmp[10] == '\0')) {
+      halftonetype = HALFTONE_GENORDERED;
+      if (halftone_tmp[10] == '-') {
+        const char *p = halftone_tmp + 11;
+        char *endp;
+        long v;
+        v = strtol(p, &endp, 10);
+        if (endp != p) { ht_frequency = (int)v; p = endp; }
+        if (*p == '-') {
+          p++;
+          v = strtol(p, &endp, 10);
+          if (endp != p) { ht_angle = (int)v; p = endp; }
+          if (*p == '-') {
+            p++;
+            v = strtol(p, &endp, 10);
+            if (endp != p) ht_dotshape = (int)v;
+          }
+        }
+      }
+    }
   }
 
   /* For bi-level type, also check print-color-mode, the way it is
@@ -1127,6 +1150,24 @@ main (int argc, char **argv, char *envp[])
   if (halftonetype == HALFTONE_DITHERING) {
     fprintf(stderr, "DEBUG: Ghostscript using 8x8 ordered dithering.\n");
     cupsArrayAdd(gs_args, strdup("<< /Install { 72 72 matrix defaultmatrix dtransform abs exch abs .min .setloresscreen } >> setpagedevice"));
+  }
+
+  /* Ghostscript .genordered advanced ordered dithering
+   * PostScript HalftoneType 3 (threshold array based).
+   *
+   * This uses the .genordered operator to generate an ordered dither
+   * halftone screen with configurable frequency, angle and dot shape.
+   *
+   * Dot shapes:
+   * 0=CIRCLE, 1=REDBOOK, 2=INVERTED, 3=RHOMBOID, 4=LINE_X, 5=LINE_Y,
+   * 6=DIAMOND1, 7=DIAMOND2, 8=ROUNDSPOT */
+  if (halftonetype == HALFTONE_GENORDERED) {
+    fprintf(stderr, "DEBUG: Ghostscript using .genordered halftone (frequency=%d angle=%d dotshape=%d).\n",
+	    ht_frequency, ht_angle, ht_dotshape);
+    snprintf(tmpstr, sizeof(tmpstr),
+             "<< /Frequency %d /Angle %d /DotShape %d >> .genordered /Default exch /Halftone defineresource sethalftone { } settransfer 0.003 setsmoothness",
+	     ht_frequency, ht_angle, ht_dotshape);
+    cupsArrayAdd(gs_args, strdup(tmpstr));
   }
 
   /* Mark the end of PostScript commands supplied on the Ghostscript command

--- a/filter/gstoraster.c
+++ b/filter/gstoraster.c
@@ -71,8 +71,47 @@ typedef enum
   HALFTONE_FOO2ZJS,
   HALFTONE_BI_LEVEL,
   HALFTONE_DITHERING,
-  HALFTONE_GENORDERED
+  HALFTONE_GENORDERED,
+  HALFTONE_SPOT
 } cups_halftone_type_t;
+
+static const char *ht_spot_functions[] = {
+  "{dup mul exch dup mul add 1 exch sub}",         /* 0  SimpleDot */
+  "{dup mul exch dup mul add 1 sub}",              /* 1  InvertedSimpleDot */
+  "{360 mul sin 2 div exch 360 mul sin 2 div add}",/* 2  DoubleDot */
+  "{360 mul sin 2 div exch 360 mul sin 2 div add neg}",/* 3 InvertedDoubleDot */
+  "{180 mul cos exch 180 mul cos add 2 div}",      /* 4  CosineDot */
+  "{360 mul sin 2 div exch 2 div 360 mul sin 2 div add}",    /* 5  Double */
+  "{360 mul sin 2 div exch 2 div 360 mul sin 2 div add neg}",/* 6  InvertedDouble */
+  "{exch pop abs neg}",                            /* 7  Line */
+  "{pop}",                                         /* 8  LineX */
+  "{exch pop}",                                    /* 9  LineY */
+  "{abs exch abs 2 copy add 1.0 le"
+  " {dup mul exch dup mul add 1 exch sub}"
+  " {1 sub dup mul exch 1 sub dup mul add 1 sub}"
+  " ifelse}",                                      /* 10 Round */
+  "{abs exch abs 2 copy 3 mul exch 4 mul add 3 sub dup 0 lt"
+  " {pop dup mul exch 0.75 div dup mul add 4 div 1 exch sub}"
+  " {dup 1 gt"
+  " {pop 1 exch sub dup mul exch 1 exch sub 0.75 div dup mul add 4 div 1 sub}"
+  " {0.5 exch sub exch pop exch pop}}"
+  " ifelse}ifelse}",                               /* 11 Ellipse */
+  "{dup mul 0.9 mul exch dup mul add 1 exch sub}", /* 12 EllipseA */
+  "{dup mul 0.9 mul exch dup mul add 1 sub}",      /* 13 InvertedEllipseA */
+  "{dup 5 mul 8 div mul exch dup mul exch add sqrt 1 exch sub}", /* 14 EllipseB */
+  "{dup mul exch dup mul 0.9 mul add 1 exch sub}", /* 15 EllipseC */
+  "{dup mul exch dup mul 0.9 mul add 1 sub}",      /* 16 InvertedEllipseC */
+  "{abs exch abs 2 copy lt {exch} if pop neg}",    /* 17 Square */
+  "{abs exch abs 2 copy gt {exch} if pop neg}",    /* 18 Cross */
+  "{abs exch abs 0.9 mul add 2 div}",              /* 19 Rhomboid */
+  "{abs exch abs 2 copy add 0.75 le"
+  " {dup mul exch dup mul add 1 exch sub}"
+  " {2 copy add 1.23 le"
+  " {0.85 mul add 1 exch sub}"
+  " {1 sub dup mul exch 1 sub dup mul add 1 sub}"
+  " ifelse} ifelse}"                               /* 20 Diamond */
+};
+#define HT_SPOT_FUNCTIONS_COUNT ((int)(sizeof(ht_spot_functions)/sizeof(ht_spot_functions[0])))
 
 #ifdef CUPS_RASTER_SYNCv1
 typedef cups_page_header2_t gs_page_header;
@@ -1026,6 +1065,27 @@ main (int argc, char **argv, char *envp[])
         }
       }
     }
+    else if (!strncasecmp(halftone_tmp, "spot", 4) &&
+             (halftone_tmp[4] == '-' || halftone_tmp[4] == '\0')) {
+      halftonetype = HALFTONE_SPOT;
+      if (halftone_tmp[4] == '-') {
+        const char *p = halftone_tmp + 5;
+        char *endp;
+        long v;
+        v = strtol(p, &endp, 10);
+        if (endp != p) { ht_frequency = (int)v; p = endp; }
+        if (*p == '-') {
+          p++;
+          v = strtol(p, &endp, 10);
+          if (endp != p) { ht_angle = (int)v; p = endp; }
+          if (*p == '-') {
+            p++;
+            v = strtol(p, &endp, 10);
+            if (endp != p) ht_dotshape = (int)v;
+          }
+        }
+      }
+    }
   }
 
   /* For bi-level type, also check print-color-mode, the way it is
@@ -1167,6 +1227,21 @@ main (int argc, char **argv, char *envp[])
     snprintf(tmpstr, sizeof(tmpstr),
              "<< /Frequency %d /Angle %d /DotShape %d >> .genordered /Default exch /Halftone defineresource sethalftone { } settransfer 0.003 setsmoothness",
 	     ht_frequency, ht_angle, ht_dotshape);
+    cupsArrayAdd(gs_args, strdup(tmpstr));
+  }
+
+  /* PostScript HalftoneType 1 spot-function halftone algorithm.
+   *
+   * Spot functions are from PDF specification, see ht_spot_functions array. */
+  if (halftonetype == HALFTONE_SPOT) {
+    int shape = ht_dotshape;
+    if (shape < 0) shape = 0;
+    if (shape >= HT_SPOT_FUNCTIONS_COUNT) shape = HT_SPOT_FUNCTIONS_COUNT - 1;
+    fprintf(stderr, "DEBUG: Ghostscript using Spot halftone (frequency=%d angle=%d dotshape=%d).\n",
+	    ht_frequency, ht_angle, shape);
+    snprintf(tmpstr, sizeof(tmpstr),
+             "<< /HalftoneType 1 /Frequency %d /Angle %d /SpotFunction %s >> /Default exch /Halftone defineresource sethalftone",
+	     ht_frequency, ht_angle, ht_spot_functions[shape]);
     cupsArrayAdd(gs_args, strdup(tmpstr));
   }
 


### PR DESCRIPTION
Everything from libcupsfilters MR: https://github.com/OpenPrinting/libcupsfilters/pull/160

Add new dithering and halftoning algorithms in addition to the [existing](https://github.com/OpenPrinting/cups-filters/pull/642) `stochastic`, `bi-level` and `foo2zjs` algorithms.  
Controlled either with `halftone-type` job option or `cupsHalftoneType` PPD option.

- `dithering`, forces 8x8 ordered dithering (no halftone) used only for low DPI in Ghostscript by default
- `genordered`, a configurable halftone+ordered dithering algorithm
- `spot`, a configurable halftone algorithm from PDF specification

```
* -o halftone-type=dithering, forces 8x8 ordered dithering
* -o halftone-type=genordered[-frequency][-angle][-dotshape]
* -o halftone-type=spot[-frequency][-angle][-dotshape]

genordered is a halftone+ordered dithering algorithm,
  frequency - line-per-inch, number of halftone cells per inch.
              Lower produces larger dots, higher - smaller.
              Values good for 203DPI label printer: 50-60
                              600DPI laser printer: 106-150
  angle - screen orientation, in degrees.
  dotshape - one of:
    0=CIRCLE, 1=REDBOOK, 2=INVERTED, 3=RHOMBOID, 4=LINE_X, 5=LINE_Y,
    6=DIAMOND1, 7=DIAMOND2, 8=ROUNDSPOT

spot is a halftone algorithm from PDF specification,
  frequency, angle - same as for genordered
  dotshape - one of:
    0=SimpleDot 1=InvertedSimpleDot 2=DoubleDot 3=InvertedDoubleDot
    4=CosineDot 5=Double 6=InvertedDouble 7=Line 8=LineX 9=LineY 10=Round
    11=Ellipse 12=EllipseA 13=InvertedEllipseA 14=EllipseB 15=EllipseC
    16=InvertedEllipseC 17=Square 18=Cross 19=Rhomboid 20=Diamond
```

`dithering` is mostly useful for label and other low-DPI printers, other algorithms are for all printers.

### Source image

<img width="384" height="384" alt="orig" src="https://github.com/user-attachments/assets/7a8e0bd4-58aa-44bf-b1b9-350433c941e3" />

### Stock configuration, no halftone-type

<img width="384" height="384" alt="00_stock pbm" src="https://github.com/user-attachments/assets/293af2ba-a13c-4e0e-b60c-82ce87847eb6" />

### Stochastic

<img width="384" height="384" alt="04_stocht pbm" src="https://github.com/user-attachments/assets/4ca5cf06-1bb5-45fc-9144-ce45d8008b4f" />

### 8x8 Dithering

<img width="384" height="384" alt="03_8x8dither pbm" src="https://github.com/user-attachments/assets/71995b27-2efb-48f6-a351-706d40a860c2" />

### genordered-60-135

<img width="384" height="384" alt="01_genordered pbm" src="https://github.com/user-attachments/assets/d19b3f24-bf07-4428-b268-233b5deea75d" />

### spot-60-135

<img width="384" height="384" alt="02_PDF_SimpleDot pbm" src="https://github.com/user-attachments/assets/e337f4aa-2173-4d8e-ae70-68007a99babc" />
