### PR TITLE
rastertopclx: check cfLutNew() result before dereferencing dither LUT

### DIFF
--- a/filter/rastertopclx.c
+++ b/filter/rastertopclx.c
@@ -440,6 +440,12 @@ StartPage(cf_filter_data_t      *data,	// I - filter data
       if (!DitherLuts[plane])
         DitherLuts[plane] = cfLutNew(2, default_lut, logfunc, ld);
 
+      if (!DitherLuts[plane])
+      {
+	fputs("ERROR: Unable to allocate dither lookup table\n", stderr);
+	exit(1);
+      }
+
       if (DitherLuts[plane][4095].pixel > 1)
 	DotBits[plane] = 2;
       else


### PR DESCRIPTION
In StartPage(), when a per-plane dither LUT is missing it is filled in with cfLutNew(2, default_lut, ...). cfLutNew() calls calloc() internally and returns NULL on allocation failure, but the result is used immediately (DitherLuts[plane][4095].pixel) without a check, so a failed allocation crashes the filter.

Bail out with an error message if cfLutNew() returns NULL, matching how rastertoescpx handles fatal setup failures. Fixes #697 (rastertopclx case).