### PR TITLE
foomatic-rip: check getenv("HOME") result before use

### DIFF
--- a/filter/foomatic-rip/spooler.c
+++ b/filter/foomatic-rip/spooler.c
@@ -225,8 +225,16 @@ init_direct(list_t *arglist,
   char tmp [1024];
   listitem_t *i;
   char user_default_path [PATH_MAX];
-
-  strlcpy(user_default_path, getenv("HOME"), 256);
+  
+  char *home = getenv("HOME");
+  if (home)
+    strlcpy(user_default_path, home, 256);
+  else
+  {
+    _log("HOME environment variable not set; using current directory for Foomatic user defaults.\n");
+    strlcpy(user_default_path, ".", 256);
+  }
+  
   strlcat(user_default_path, "/.foomatic/", 256);
 
   // Which files do we want to print?


### PR DESCRIPTION
In init_direct() (filter/foomatic-rip/spooler.c), getenv("HOME") is passed straight into strlcpy() with no NULL check. When HOME is unset, getenv returns NULL and the filter crashes. This guards the result, falling back to the current directory and logging via _log(), matching the existing getenv() guard pattern already used at line 51 of the same file.
This addresses the second case from #697 (the foomatic-rip/spooler.c NULL deref), which is not covered by #701 (that PR handles the rastertopclx.c case). Using "Addresses" rather than "Fixes" so #697 isn't auto-closed while the other case is still open.