### PR TITLE
foomatic-rip: use bounds-safe string writes (#697)

### DIFF
--- a/filter/foomatic-rip/options.c
+++ b/filter/foomatic-rip/options.c
@@ -423,7 +423,7 @@ assure_option(const char *name)
     strlcpy(opt->name, name, 128);
 
   // set varname
-  strcpy(opt->varname, opt->name);
+  strlcpy(opt->varname, opt->name, sizeof(opt->varname));
   strrepl(opt->varname, "-/.", '_');
 
   // Default execution style is 'G' (PostScript) since all arguments for
@@ -2463,8 +2463,9 @@ build_commandline(int optset,
     {
       if (isempty(userval))
 	continue;
-      s = malloc(strlen(opt->name) + strlen(userval) + 20);
-      sprintf(s, "%s=%s %%Y", opt->name, userval);
+      size_t s_size = strlen(opt->name) + strlen(userval) + 20;
+      s = malloc(s_size);
+      snprintf(s, s_size, "%s=%s %%Y", opt->name, userval);
       dstrreplace(cmdline, "%Y", s, 0);
       free(s);
     }

--- a/filter/foomatic-rip/util.c
+++ b/filter/foomatic-rip/util.c
@@ -850,7 +850,7 @@ dstrcpy(dstr_t *ds,
     ds->data = realloc(ds->data, ds->alloc);
   }
 
-  strcpy(ds->data, src);
+  memcpy(ds->data, src, srclen + 1);
   ds->len = srclen;
 }
 


### PR DESCRIPTION
### What this fixes

Follow-up to #702 for the remaining CodeQL "unbounded write" alerts in #697.

Three `strcpy`/`sprintf` calls in foomatic-rip were flagged as potential overflows. The destinations are actually sized correctly already, but the writes aren't bounded in a way CodeQL can verify, so this swaps them for explicit bounded equivalents.

### The changes

- `options.c` — `strcpy(opt->varname, opt->name)` → `strlcpy` with `sizeof(opt->varname)`. Both fields are `char[128]` and `name` is filled with `strlcpy`, so the length was already safe.
- `options.c` — the `%Y` command fragment now uses `snprintf` with the same size the buffer is `malloc`'d to.
- `util.c` — `dstrcpy()` uses `memcpy(ds->data, src, srclen + 1)`; `src` is NULL-checked above and the buffer is `realloc`'d to fit, so this copies the string plus its terminator within bounds.

No behavioural change — same output, explicit bounds.